### PR TITLE
fix(warehouse): drop supergateway, use postgres-mcp native streamable-http

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -19,7 +19,13 @@ services:
     environment:
       PORT: "8080"
       WORKER_SHARED_SECRET: ${WORKER_SHARED_SECRET:?set WORKER_SHARED_SECRET in .env}
-      UPSTREAM_WAREHOUSE: "http://warehouse_mcp:8080"
+      # warehouse_mcp now runs postgres-mcp natively with --transport streamable-http.
+      # FastMCP (the MCP SDK behind postgres-mcp) serves at /mcp/ by default and does
+      # not expose a CLI arg to change it, so we include /mcp in the target. The gateway's
+      # pathRewrite strips the public prefix /mcp/warehouse and http-proxy-middleware
+      # concatenates the remainder onto the target, so the upstream sees /mcp/<rest>.
+      # When postgres-mcp 0.4.0+ ships with a path arg we can simplify this back.
+      UPSTREAM_WAREHOUSE: "http://warehouse_mcp:8080/mcp"
       UPSTREAM_META_ADS: "http://meta_ads_mcp:8080"
       UPSTREAM_FACEBOOK_CHOIZ: "http://facebook_choiz_mcp:8080"
       UPSTREAM_FACEBOOK_TIMELESS: "http://facebook_timeless_mcp:8080"

--- a/mcp/warehouse/Dockerfile
+++ b/mcp/warehouse/Dockerfile
@@ -1,44 +1,48 @@
-# Combined image for the warehouse MCP:
-#   - postgres-mcp runs as a stdio-transport subprocess (its native mode).
-#   - supergateway exposes it over MCP Streamable HTTP on :8080, which is the
-#     transport claude.ai speaks.
+# Warehouse MCP — postgres-mcp with native Streamable HTTP transport.
 #
-# We combine them in one container because supergateway only translates
-# stdio -> (sse|ws|streamableHttp); it does NOT do sse -> streamableHttp. So
-# we need postgres-mcp on stdin/stdout of supergateway.
+# History: previously this image bundled supergateway to translate stdio
+# (postgres-mcp's only transport in v0.3.0) to MCP Streamable HTTP. That
+# combination caused a child-process leak: each request to the gateway
+# spawned a new postgres-mcp Python child, but supergateway in --stateless
+# mode did not reap them on completion. Containers grew to 2.5+ GB of RAM
+# after a few queries (9 zombie postgres-mcp processes × ~280 MB each),
+# eventually starving the host of memory and triggering the recurring
+# "tunnel zombie" pattern documented in MEMORY.md / project_tunnel_zombie_*.
 #
-# Base is python-slim (Debian) rather than node-alpine because installing a
-# Python package cleanly inside Alpine's musl + pipx combo has proven fragile
-# on ARM64. Adding Node on top of a Python base is straightforward.
+# Fix (2026-05-06): postgres-mcp's main branch (commit 07eb329c, Jan 2026)
+# added a native streamable-http transport via mcp.server.fastmcp's
+# run_streamable_http_async(). This eliminates the supergateway hop entirely:
+# one persistent Python process serves all requests in-band. No more child
+# zombies; Python's GC reclaims per-query allocations cleanly.
+#
+# We pin to the exact commit 07eb329c rather than a moving branch so builds
+# are reproducible. When upstream publishes 0.4.0+ on PyPI we can switch back
+# to a versioned pip install.
 
 FROM python:3.12-slim
 
-# Node.js LTS + build tools needed for native npm deps.
+# Just curl + ca-certs for any HTTPS deps the wheel pull may need.
 RUN apt-get update \
- && apt-get install -y --no-install-recommends curl ca-certificates gnupg \
- && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
- && apt-get install -y --no-install-recommends nodejs \
+ && apt-get install -y --no-install-recommends ca-certificates curl git \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
-# postgres-mcp from PyPI. We use a venv under /opt so it doesn't conflict
-# with the system Python environment (PEP 668).
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:${PATH}"
-RUN pip install --no-cache-dir postgres-mcp
 
-# supergateway from npm, global install.
-RUN npm install -g supergateway
+# Pin to the commit that introduced --transport streamable-http support.
+# https://github.com/crystaldba/postgres-mcp/commit/07eb329c
+RUN pip install --no-cache-dir 'git+https://github.com/crystaldba/postgres-mcp.git@07eb329c'
 
 EXPOSE 8080
 
 # DATABASE_URI is read from env by postgres-mcp.
-# --stdio "<cmd>" spawns postgres-mcp, supergateway proxies the JSON-RPC
-# stream out on :8080 as MCP Streamable HTTP.
-ENTRYPOINT ["supergateway"]
+# --access-mode=restricted blocks DML/DDL; only SELECT/EXPLAIN are allowed.
+# --transport streamable-http serves MCP Streamable HTTP directly on 0.0.0.0:8080.
+ENTRYPOINT ["postgres-mcp"]
 CMD [ \
-  "--stdio", "postgres-mcp --access-mode=restricted", \
-  "--outputTransport", "streamableHttp", \
-  "--port", "8080", \
-  "--streamableHttpPath", "/" \
+  "--transport", "streamable-http", \
+  "--streamable-http-host", "0.0.0.0", \
+  "--streamable-http-port", "8080", \
+  "--access-mode", "restricted" \
 ]


### PR DESCRIPTION
## Summary

Replaces the `supergateway`-wrapped `postgres-mcp` setup in `warehouse_mcp` with `postgres-mcp` running its own native streamable-http transport. Eliminates the underlying memory leak that has been causing recurring host-zombie incidents.

## Root cause

Live measurement on 2026-05-06 confirmed **9 zombie `postgres-mcp` Python processes** alive simultaneously inside the warehouse container (PIDs 60, 62, 64, 66, 84, 90, 92, 94, 96), each consuming ~280 MB. Total: 2.5 GB matching cgroup usage exactly.

`supergateway --stateless` spawns a new Python child per request but does NOT reap the previous one. After ~10 queries, the container is hosting a small fleet of ghost processes still pinned in memory, all stuck waiting on stdin that supergateway never closed.

This is `supergateway`'s bug, not `postgres-mcp`'s. The user-running-locally case never sees it because Claude Desktop pipes stdio to a single child for the lifetime of the connection.

## Fix

`postgres-mcp`'s `main` branch (commit [`07eb329c`](https://github.com/crystaldba/postgres-mcp/commit/07eb329c), Jan 2026) added native `--transport streamable-http` via `FastMCP.run_streamable_http_async()`. This is exactly what `claude.ai` expects, no translation layer needed.

After this PR: one persistent Python process per container, Python GC reclaims per-query allocations cleanly, zero child zombies.

## Container changes

- Removed Node 20 + `supergateway` install from the image (smaller base).
- Pin to commit `07eb329c` via `pip install git+...@<sha>` so builds are reproducible. We can switch back to a PyPI version when upstream cuts 0.4.0+.
- `mcp/warehouse/Dockerfile` ENTRYPOINT/CMD now invokes `postgres-mcp` directly with `--transport streamable-http --streamable-http-host 0.0.0.0 --streamable-http-port 8080 --access-mode restricted`.

## compose.yml

`UPSTREAM_WAREHOUSE` now ends in `/mcp` because FastMCP serves at `/mcp/` by default and there's no CLI flag to change it (yet — open issue upstream). The gateway's `pathRewrite` strips the public prefix `/mcp/warehouse` and `http-proxy-middleware` concatenates the remainder onto the target. End result: `claude.ai → /mcp/warehouse/` reaches `warehouse_mcp:8080/mcp/`. Inline comment in `compose.yml` documents this.

Public claude.ai URL `mcp.choiz.com.mx/mcp/warehouse/` is unchanged — no user-visible URL change.

## Test plan

- [ ] CI builds the new image cleanly.
- [ ] Deploy to EC2 (CI/CD does this automatically on merge).
- [ ] Confirm `docker stats` shows `warehouse_mcp` running at ~50-80 MB at idle (vs the 76 MB baseline before usage). If it starts at hundreds of MB, the FastMCP runtime is heavier than expected — flag and investigate.
- [ ] From inside EC2, `curl -s http://localhost:8080/mcp/warehouse/ -X POST -H 'X-Worker-Shared-Secret: ...' -H 'X-Choiz-User-Email: ...' -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"1.0"}}}'` — should return a clean MCP `initialize` response.
- [ ] In `claude.ai`: re-add the warehouse connector if needed (URL doesn't change but the protocol underneath may need a fresh handshake) and run a small SELECT. Confirm response.
- [ ] Run several queries in sequence and verify `docker stats` does NOT keep growing — should plateau, not climb to GBs like before. This is the actual acceptance criterion.
- [ ] After 30 min of mixed usage, count `postgres-mcp` processes inside the container with `docker exec ... ps -ef | grep postgres-mcp | wc -l`. Expected: **1**, not 9.

## Rollback

If something breaks, revert this PR. Older Dockerfile + compose.yml restore the supergateway path. The leak comes back but the system works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)