### PR TITLE
fix(gateway): strip trailing slash to avoid FastMCP 307 redirect

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -75,8 +75,22 @@ for (const [prefix, target] of Object.entries(upstreams)) {
     createProxyMiddleware({
       target,
       changeOrigin: true,
-      // Strip the prefix so the upstream sees the path it expects (e.g. /sse).
-      pathRewrite: { [`^${prefix}`]: "" },
+      // Strip the prefix AND any trailing slash so the upstream sees the path
+      // it expects without a stray "/". Two regexes applied in order:
+      //   1. `^<prefix>/?$`  matches the prefix exactly, with optional trailing
+      //      slash. Replaces with "" so the request URL becomes empty (the
+      //      target's own path is kept verbatim).
+      //   2. `^<prefix>/`    matches the prefix followed by a sub-path. Replaces
+      //      with "/" so e.g. /mcp/foo/messages becomes /messages, then gets
+      //      appended to the target path normally.
+      // This matters for upstreams that 307-redirect requests with a trailing
+      // slash to the slashless canonical URL. FastMCP serving streamable-http
+      // at /mcp does this — the redirect's Location is an absolute URL using
+      // the internal Docker hostname, which is unreachable from claude.ai.
+      pathRewrite: {
+        [`^${prefix}/?$`]: "",
+        [`^${prefix}/`]: "/",
+      },
       // Preserve streaming (SSE, chunked responses).
       selfHandleResponse: false,
       on: {


### PR DESCRIPTION
## Summary

Companion fix to #5. After dropping supergateway from warehouse_mcp, requests with a trailing slash (`/mcp/warehouse/` — exactly what claude.ai sends) hit FastMCP's `/mcp/` and get a 307 redirect to `/mcp`. The redirect's `Location` header is an absolute internal Docker URL (`http://warehouse_mcp:8080/mcp`) that's unreachable from claude.ai, breaking every request.

Fix at the gateway: two-rule `pathRewrite` that strips the trailing slash for exact-prefix matches, while preserving normal sub-path behaviour.

## Affected MCPs

- **warehouse**: ✅ no more 307 redirect.
- **All supergateway-based MCPs (meta-ads, ga4×2, gsc×2, facebook×2, instagram×2)**: behaviour unchanged. Trace in commit message.

## Test plan

- [ ] CI builds gateway image.
- [ ] Deploy completes.
- [ ] Curl from inside EC2 to `http://localhost:8080/mcp/warehouse/` returns valid MCP `initialize` response without redirect.
- [ ] Quick smoke from claude.ai of any non-warehouse MCP confirms no regression (e.g. GA4 schema query).
- [ ] User retries warehouse query in claude.ai → should now respond.

🤖 Generated with [Claude Code](https://claude.com/claude-code)