### PR TITLE
fix(warehouse): set FASTMCP_STREAMABLE_HTTP_PATH=/ — actual fix for 307 redirect

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -19,13 +19,7 @@ services:
     environment:
       PORT: "8080"
       WORKER_SHARED_SECRET: ${WORKER_SHARED_SECRET:?set WORKER_SHARED_SECRET in .env}
-      # warehouse_mcp now runs postgres-mcp natively with --transport streamable-http.
-      # FastMCP (the MCP SDK behind postgres-mcp) serves at /mcp/ by default and does
-      # not expose a CLI arg to change it, so we include /mcp in the target. The gateway's
-      # pathRewrite strips the public prefix /mcp/warehouse and http-proxy-middleware
-      # concatenates the remainder onto the target, so the upstream sees /mcp/<rest>.
-      # When postgres-mcp 0.4.0+ ships with a path arg we can simplify this back.
-      UPSTREAM_WAREHOUSE: "http://warehouse_mcp:8080/mcp"
+      UPSTREAM_WAREHOUSE: "http://warehouse_mcp:8080"
       UPSTREAM_META_ADS: "http://meta_ads_mcp:8080"
       UPSTREAM_FACEBOOK_CHOIZ: "http://facebook_choiz_mcp:8080"
       UPSTREAM_FACEBOOK_TIMELESS: "http://facebook_timeless_mcp:8080"
@@ -71,6 +65,14 @@ services:
     image: ghcr.io/choizapp/choiz-mcp-gateway/warehouse:${IMAGE_TAG:-latest}
     environment:
       DATABASE_URI: ${WAREHOUSE_DATABASE_URL:?set WAREHOUSE_DATABASE_URL in .env}
+      # postgres-mcp uses FastMCP (mcp[cli]>=1.25.0) which defaults to serving
+      # streamable-http at /mcp. Override to / via the pydantic-settings env var
+      # (env_prefix=FASTMCP_) so the upstream serves at the same path the gateway
+      # forwards to (after pathRewrite strips the public prefix). Without this,
+      # FastMCP issues a 307 redirect to its canonical /mcp URL, but the
+      # redirect's Location uses the internal docker hostname, which is
+      # unreachable from claude.ai's vantage point.
+      FASTMCP_STREAMABLE_HTTP_PATH: "/"
     restart: unless-stopped
     # No ports: block. Gateway reaches it by service name on the internal network.
 

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -75,8 +75,22 @@ for (const [prefix, target] of Object.entries(upstreams)) {
     createProxyMiddleware({
       target,
       changeOrigin: true,
-      // Strip the prefix so the upstream sees the path it expects (e.g. /sse).
-      pathRewrite: { [`^${prefix}`]: "" },
+      // Strip the prefix AND any trailing slash so the upstream sees the path
+      // it expects without a stray "/". Two regexes applied in order:
+      //   1. `^<prefix>/?$`  matches the prefix exactly, with optional trailing
+      //      slash. Replaces with "" so the request URL becomes empty (the
+      //      target's own path is kept verbatim).
+      //   2. `^<prefix>/`    matches the prefix followed by a sub-path. Replaces
+      //      with "/" so e.g. /mcp/foo/messages becomes /messages, then gets
+      //      appended to the target path normally.
+      // This matters for upstreams that 307-redirect requests with a trailing
+      // slash to the slashless canonical URL. FastMCP serving streamable-http
+      // at /mcp does this — the redirect's Location is an absolute URL using
+      // the internal Docker hostname, which is unreachable from claude.ai.
+      pathRewrite: {
+        [`^${prefix}/?$`]: "",
+        [`^${prefix}/`]: "/",
+      },
       // Preserve streaming (SSE, chunked responses).
       selfHandleResponse: false,
       on: {

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -75,22 +75,8 @@ for (const [prefix, target] of Object.entries(upstreams)) {
     createProxyMiddleware({
       target,
       changeOrigin: true,
-      // Strip the prefix AND any trailing slash so the upstream sees the path
-      // it expects without a stray "/". Two regexes applied in order:
-      //   1. `^<prefix>/?$`  matches the prefix exactly, with optional trailing
-      //      slash. Replaces with "" so the request URL becomes empty (the
-      //      target's own path is kept verbatim).
-      //   2. `^<prefix>/`    matches the prefix followed by a sub-path. Replaces
-      //      with "/" so e.g. /mcp/foo/messages becomes /messages, then gets
-      //      appended to the target path normally.
-      // This matters for upstreams that 307-redirect requests with a trailing
-      // slash to the slashless canonical URL. FastMCP serving streamable-http
-      // at /mcp does this — the redirect's Location is an absolute URL using
-      // the internal Docker hostname, which is unreachable from claude.ai.
-      pathRewrite: {
-        [`^${prefix}/?$`]: "",
-        [`^${prefix}/`]: "/",
-      },
+      // Strip the prefix so the upstream sees the path it expects (e.g. /sse).
+      pathRewrite: { [`^${prefix}`]: "" },
       // Preserve streaming (SSE, chunked responses).
       selfHandleResponse: false,
       on: {


### PR DESCRIPTION
PR #6's gateway pathRewrite tweak didn't fix the redirect because http-proxy-middleware coerces empty path to '/'. The real fix is in compose.yml: tell FastMCP to serve at '/' via env var. Reverts the unnecessary gateway change from #6.

Verified mcp 1.25.0 uses env_prefix='FASTMCP_'.

After this lands: claude.ai → /mcp/warehouse/ → gateway strips → upstream POST /, FastMCP at / responds. No redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)