### PR TITLE
fix(warehouse): Python wrapper to set FastMCP streamable-http path = /

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -65,16 +65,13 @@ services:
     image: ghcr.io/choizapp/choiz-mcp-gateway/warehouse:${IMAGE_TAG:-latest}
     environment:
       DATABASE_URI: ${WAREHOUSE_DATABASE_URL:?set WAREHOUSE_DATABASE_URL in .env}
-      # postgres-mcp uses FastMCP (mcp[cli]>=1.25.0) which defaults to serving
-      # streamable-http at /mcp. Override to / via the pydantic-settings env var
-      # (env_prefix=FASTMCP_) so the upstream serves at the same path the gateway
-      # forwards to (after pathRewrite strips the public prefix). Without this,
-      # FastMCP issues a 307 redirect to its canonical /mcp URL, but the
-      # redirect's Location uses the internal docker hostname, which is
-      # unreachable from claude.ai's vantage point.
-      FASTMCP_STREAMABLE_HTTP_PATH: "/"
     restart: unless-stopped
     # No ports: block. Gateway reaches it by service name on the internal network.
+    # FastMCP is configured to serve streamable-http at "/" via mcp/warehouse/entrypoint.py
+    # (a Python wrapper that monkey-patches the SDK before postgres-mcp imports it).
+    # The pydantic-settings env var FASTMCP_STREAMABLE_HTTP_PATH does NOT work for
+    # this — verified empirically — because FastMCP's __init__ kwarg default
+    # overrides env vars in pydantic-settings precedence.
 
   meta_ads_mcp:
     image: ghcr.io/choizapp/choiz-mcp-gateway/meta-ads:${IMAGE_TAG:-latest}

--- a/compose.yml
+++ b/compose.yml
@@ -19,13 +19,7 @@ services:
     environment:
       PORT: "8080"
       WORKER_SHARED_SECRET: ${WORKER_SHARED_SECRET:?set WORKER_SHARED_SECRET in .env}
-      # warehouse_mcp now runs postgres-mcp natively with --transport streamable-http.
-      # FastMCP (the MCP SDK behind postgres-mcp) serves at /mcp/ by default and does
-      # not expose a CLI arg to change it, so we include /mcp in the target. The gateway's
-      # pathRewrite strips the public prefix /mcp/warehouse and http-proxy-middleware
-      # concatenates the remainder onto the target, so the upstream sees /mcp/<rest>.
-      # When postgres-mcp 0.4.0+ ships with a path arg we can simplify this back.
-      UPSTREAM_WAREHOUSE: "http://warehouse_mcp:8080/mcp"
+      UPSTREAM_WAREHOUSE: "http://warehouse_mcp:8080"
       UPSTREAM_META_ADS: "http://meta_ads_mcp:8080"
       UPSTREAM_FACEBOOK_CHOIZ: "http://facebook_choiz_mcp:8080"
       UPSTREAM_FACEBOOK_TIMELESS: "http://facebook_timeless_mcp:8080"
@@ -71,6 +65,14 @@ services:
     image: ghcr.io/choizapp/choiz-mcp-gateway/warehouse:${IMAGE_TAG:-latest}
     environment:
       DATABASE_URI: ${WAREHOUSE_DATABASE_URL:?set WAREHOUSE_DATABASE_URL in .env}
+      # postgres-mcp uses FastMCP (mcp[cli]>=1.25.0) which defaults to serving
+      # streamable-http at /mcp. Override to / via the pydantic-settings env var
+      # (env_prefix=FASTMCP_) so the upstream serves at the same path the gateway
+      # forwards to (after pathRewrite strips the public prefix). Without this,
+      # FastMCP issues a 307 redirect to its canonical /mcp URL, but the
+      # redirect's Location uses the internal docker hostname, which is
+      # unreachable from claude.ai's vantage point.
+      FASTMCP_STREAMABLE_HTTP_PATH: "/"
     restart: unless-stopped
     # No ports: block. Gateway reaches it by service name on the internal network.
 

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -75,8 +75,22 @@ for (const [prefix, target] of Object.entries(upstreams)) {
     createProxyMiddleware({
       target,
       changeOrigin: true,
-      // Strip the prefix so the upstream sees the path it expects (e.g. /sse).
-      pathRewrite: { [`^${prefix}`]: "" },
+      // Strip the prefix AND any trailing slash so the upstream sees the path
+      // it expects without a stray "/". Two regexes applied in order:
+      //   1. `^<prefix>/?$`  matches the prefix exactly, with optional trailing
+      //      slash. Replaces with "" so the request URL becomes empty (the
+      //      target's own path is kept verbatim).
+      //   2. `^<prefix>/`    matches the prefix followed by a sub-path. Replaces
+      //      with "/" so e.g. /mcp/foo/messages becomes /messages, then gets
+      //      appended to the target path normally.
+      // This matters for upstreams that 307-redirect requests with a trailing
+      // slash to the slashless canonical URL. FastMCP serving streamable-http
+      // at /mcp does this — the redirect's Location is an absolute URL using
+      // the internal Docker hostname, which is unreachable from claude.ai.
+      pathRewrite: {
+        [`^${prefix}/?$`]: "",
+        [`^${prefix}/`]: "/",
+      },
       // Preserve streaming (SSE, chunked responses).
       selfHandleResponse: false,
       on: {

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -75,22 +75,8 @@ for (const [prefix, target] of Object.entries(upstreams)) {
     createProxyMiddleware({
       target,
       changeOrigin: true,
-      // Strip the prefix AND any trailing slash so the upstream sees the path
-      // it expects without a stray "/". Two regexes applied in order:
-      //   1. `^<prefix>/?$`  matches the prefix exactly, with optional trailing
-      //      slash. Replaces with "" so the request URL becomes empty (the
-      //      target's own path is kept verbatim).
-      //   2. `^<prefix>/`    matches the prefix followed by a sub-path. Replaces
-      //      with "/" so e.g. /mcp/foo/messages becomes /messages, then gets
-      //      appended to the target path normally.
-      // This matters for upstreams that 307-redirect requests with a trailing
-      // slash to the slashless canonical URL. FastMCP serving streamable-http
-      // at /mcp does this — the redirect's Location is an absolute URL using
-      // the internal Docker hostname, which is unreachable from claude.ai.
-      pathRewrite: {
-        [`^${prefix}/?$`]: "",
-        [`^${prefix}/`]: "/",
-      },
+      // Strip the prefix so the upstream sees the path it expects (e.g. /sse).
+      pathRewrite: { [`^${prefix}`]: "" },
       // Preserve streaming (SSE, chunked responses).
       selfHandleResponse: false,
       on: {

--- a/mcp/warehouse/Dockerfile
+++ b/mcp/warehouse/Dockerfile
@@ -34,12 +34,19 @@ ENV PATH="/opt/venv/bin:${PATH}"
 # https://github.com/crystaldba/postgres-mcp/commit/07eb329c
 RUN pip install --no-cache-dir 'git+https://github.com/crystaldba/postgres-mcp.git@07eb329c'
 
+COPY entrypoint.py /opt/entrypoint.py
+
 EXPOSE 8080
 
+# We invoke postgres-mcp through entrypoint.py so we can monkey-patch
+# FastMCP to serve streamable-http at "/" rather than the SDK default "/mcp".
+# See entrypoint.py for the full rationale; the patch is needed because
+# FastMCP's __init__ kwarg default has higher precedence than the
+# corresponding pydantic-settings env var (FASTMCP_STREAMABLE_HTTP_PATH).
+#
 # DATABASE_URI is read from env by postgres-mcp.
 # --access-mode=restricted blocks DML/DDL; only SELECT/EXPLAIN are allowed.
-# --transport streamable-http serves MCP Streamable HTTP directly on 0.0.0.0:8080.
-ENTRYPOINT ["postgres-mcp"]
+ENTRYPOINT ["python", "/opt/entrypoint.py"]
 CMD [ \
   "--transport", "streamable-http", \
   "--streamable-http-host", "0.0.0.0", \

--- a/mcp/warehouse/entrypoint.py
+++ b/mcp/warehouse/entrypoint.py
@@ -1,0 +1,63 @@
+"""Warehouse MCP entrypoint that patches FastMCP to serve at "/" instead of "/mcp".
+
+Why this exists:
+  FastMCP (mcp 1.25.0) hard-codes ``streamable_http_path: str = "/mcp"`` as a
+  default in its ``__init__`` signature. When postgres-mcp calls
+  ``FastMCP(name=...)`` without specifying that kwarg, the function-level
+  default propagates into Settings as an explicit kwarg, which has higher
+  precedence than environment variables in pydantic-settings — so setting
+  ``FASTMCP_STREAMABLE_HTTP_PATH=/`` in the container env does NOT work.
+
+  Without overriding the path, FastMCP serves at ``/mcp`` and issues a 307
+  redirect for any request to ``/`` or ``/mcp/`` whose Location header
+  references the internal Docker hostname (``http://warehouse_mcp:8080/mcp``),
+  which is unreachable from claude.ai.
+
+Workaround:
+  Subclass ``FastMCP`` and inject ``streamable_http_path="/"`` as a kwarg
+  default. Patch the symbol on BOTH the source module (``mcp.server.fastmcp.server``)
+  and the package re-export (``mcp.server.fastmcp``) before postgres-mcp imports
+  ``FastMCP`` by name. Then defer to ``postgres_mcp.server.main()``.
+
+Switch back to the upstream CLI when one of these lands:
+  - postgres-mcp 0.4.0 with a CLI flag like ``--streamable-http-path``,
+  - or mcp SDK changes ``streamable_http_path`` to be env-overridable.
+
+See: https://github.com/crystaldba/postgres-mcp/blob/07eb329c/src/postgres_mcp/server.py
+"""
+from __future__ import annotations
+
+import asyncio
+
+import mcp.server.fastmcp as _fastmcp_pkg
+from mcp.server.fastmcp import server as _fastmcp_server_mod
+
+# Capture the original class before any other module imports it by name.
+_OrigFastMCP = _fastmcp_pkg.FastMCP
+
+
+class _FastMCPRootPath(_OrigFastMCP):
+    """FastMCP that defaults ``streamable_http_path`` to ``/``."""
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("streamable_http_path", "/")
+        super().__init__(*args, **kwargs)
+
+
+# Patch BOTH the source module and the package-level re-export. Python's
+# ``from mcp.server.fastmcp import FastMCP`` looks up the attribute on the
+# package object, which is set at __init__.py load time from the original
+# source module. So patching only the source module is not enough — any code
+# that does ``from mcp.server.fastmcp import FastMCP`` would still get the
+# pre-patch symbol because __init__.py already cached it.
+_fastmcp_server_mod.FastMCP = _FastMCPRootPath  # type: ignore[misc]
+_fastmcp_pkg.FastMCP = _FastMCPRootPath  # type: ignore[misc]
+
+# Now import postgres-mcp; its ``server`` module evaluates
+# ``from mcp.server.fastmcp import FastMCP`` at load time, which reads the
+# (now patched) symbol off the package.
+from postgres_mcp.server import main  # noqa: E402
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
PR #7's env var approach was a dead-end. Verified empirically: even with FASTMCP_STREAMABLE_HTTP_PATH=/ in the container env, FastMCP's settings.streamable_http_path stays at '/mcp' because FastMCP.__init__ has streamable_http_path='/mcp' as a kwarg default, which pydantic-settings precedence-rules above env vars.

This PR adds a small Python wrapper (mcp/warehouse/entrypoint.py) that subclasses FastMCP and forces the kwarg before postgres-mcp imports it. Patches both the source module and the package re-export to be safe.

After deploy, smoke test: curl through gateway should return MCP initialize response (not 307 not 404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)