### PR TITLE
fix(warehouse): retry FastMCP path patch with __init__ replacement (no subclass)

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -65,16 +65,12 @@ services:
     image: ghcr.io/choizapp/choiz-mcp-gateway/warehouse:${IMAGE_TAG:-latest}
     environment:
       DATABASE_URI: ${WAREHOUSE_DATABASE_URL:?set WAREHOUSE_DATABASE_URL in .env}
-      # postgres-mcp uses FastMCP (mcp[cli]>=1.25.0) which defaults to serving
-      # streamable-http at /mcp. Override to / via the pydantic-settings env var
-      # (env_prefix=FASTMCP_) so the upstream serves at the same path the gateway
-      # forwards to (after pathRewrite strips the public prefix). Without this,
-      # FastMCP issues a 307 redirect to its canonical /mcp URL, but the
-      # redirect's Location uses the internal docker hostname, which is
-      # unreachable from claude.ai's vantage point.
-      FASTMCP_STREAMABLE_HTTP_PATH: "/"
     restart: unless-stopped
     # No ports: block. Gateway reaches it by service name on the internal network.
+    # FastMCP serves streamable-http at "/" via the in-place __init__ patch in
+    # mcp/warehouse/entrypoint.py. The pydantic-settings env var
+    # FASTMCP_STREAMABLE_HTTP_PATH does NOT work for this — verified empirically —
+    # because FastMCP's __init__ kwarg default has higher precedence.
 
   meta_ads_mcp:
     image: ghcr.io/choizapp/choiz-mcp-gateway/meta-ads:${IMAGE_TAG:-latest}

--- a/mcp/warehouse/Dockerfile
+++ b/mcp/warehouse/Dockerfile
@@ -34,12 +34,19 @@ ENV PATH="/opt/venv/bin:${PATH}"
 # https://github.com/crystaldba/postgres-mcp/commit/07eb329c
 RUN pip install --no-cache-dir 'git+https://github.com/crystaldba/postgres-mcp.git@07eb329c'
 
+COPY entrypoint.py /opt/entrypoint.py
+
 EXPOSE 8080
 
+# We invoke postgres-mcp through entrypoint.py so we can monkey-patch
+# FastMCP.__init__ in place to default streamable_http_path="/". The
+# patch is applied to the original class (NOT a subclass) so generic
+# parameterisation `FastMCP[X]` keeps working — that's the trap that
+# bit us in the previous attempt.
+#
 # DATABASE_URI is read from env by postgres-mcp.
 # --access-mode=restricted blocks DML/DDL; only SELECT/EXPLAIN are allowed.
-# --transport streamable-http serves MCP Streamable HTTP directly on 0.0.0.0:8080.
-ENTRYPOINT ["postgres-mcp"]
+ENTRYPOINT ["python", "/opt/entrypoint.py"]
 CMD [ \
   "--transport", "streamable-http", \
   "--streamable-http-host", "0.0.0.0", \

--- a/mcp/warehouse/entrypoint.py
+++ b/mcp/warehouse/entrypoint.py
@@ -1,0 +1,55 @@
+"""Warehouse MCP entrypoint that patches FastMCP to serve at "/" instead of "/mcp".
+
+Why this exists:
+  FastMCP (mcp 1.25.0) hard-codes ``streamable_http_path: str = "/mcp"`` as a
+  default in its ``__init__`` signature. When postgres-mcp calls
+  ``FastMCP(name=...)`` without specifying that kwarg, the function-level
+  default propagates into Settings as an explicit kwarg, which has higher
+  precedence than environment variables in pydantic-settings — so setting
+  ``FASTMCP_STREAMABLE_HTTP_PATH=/`` in the container env does NOT work.
+
+  Without overriding the path, FastMCP serves at ``/mcp`` and issues a 307
+  redirect for any request to ``/`` whose Location header references the
+  internal Docker hostname (``http://warehouse_mcp:8080/mcp``), which is
+  unreachable from claude.ai.
+
+Workaround:
+  Replace ``FastMCP.__init__`` in-place to inject ``streamable_http_path="/"``
+  as a kwarg default. We must NOT subclass: ``FastMCP`` is a Generic
+  (``FastMCP[LifespanResultT]``) and any plain subclass loses the generic
+  parameterisation, which breaks postgres-mcp's runtime type evaluation
+  with ``TypeError: <class '__main__._FastMCPRootPath'> is not a generic class``
+  when pydantic resolves forward refs in field annotations.
+
+Switch back to the upstream CLI when one of these lands:
+  - postgres-mcp 0.4.0 with a CLI flag like ``--streamable-http-path``,
+  - or mcp SDK changes ``streamable_http_path`` so its env var actually wins.
+
+See: https://github.com/crystaldba/postgres-mcp/blob/07eb329c/src/postgres_mcp/server.py
+"""
+from __future__ import annotations
+
+import asyncio
+
+import mcp.server.fastmcp as _fastmcp_pkg
+
+_orig_init = _fastmcp_pkg.FastMCP.__init__
+
+
+def _patched_init(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+    kwargs.setdefault("streamable_http_path", "/")
+    _orig_init(self, *args, **kwargs)
+
+
+# Replace __init__ in place; the class object stays the same so
+# ``FastMCP[X]`` generic parameterisation continues to work.
+_fastmcp_pkg.FastMCP.__init__ = _patched_init  # type: ignore[method-assign]
+
+# Now import postgres-mcp; its ``server`` module evaluates
+# ``from mcp.server.fastmcp import FastMCP`` at load time and gets the
+# (in-place-patched) class.
+from postgres_mcp.server import main  # noqa: E402
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
PR #8 broke the container (subclass lost generic). This retry replaces FastMCP.__init__ in place — no subclass, generic-ness preserved.

Validated in live container before pushing: FastMCP[NoneType] still works, streamable_http_path='/' on postgres_mcp.server.mcp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)