### PR TITLE
fix(facebook): drop supergateway, run FastMCP streamable-http directly

### DIFF
--- a/mcp/facebook/Dockerfile
+++ b/mcp/facebook/Dockerfile
@@ -2,26 +2,36 @@
 #
 # Source: https://github.com/Choizapp/choiz-facebook-mcp (Choiz fork of
 # HagaiHen/facebook-mcp-server with Graph API v23 + deprecated-metric fixes).
-# Stack: Python (server.py uses mcp[cli] with stdio transport).
-# We wrap it with supergateway so the container exposes MCP Streamable HTTP
-# on :8080, which is what claude.ai speaks.
+# Stack: Python (server.py registers tools on a FastMCP instance — it does NOT
+# call mcp.run()).
+#
+# History: previously bundled Node + supergateway to translate the MCP's stdio
+# transport (via `mcp run /app/server.py`) into MCP Streamable HTTP. The same
+# child-process leak that hit warehouse_mcp on 2026-05-06 affects this image
+# too: supergateway --stateless spawns a Python child per request and never
+# reaps them, so RAM grows indefinitely under sustained load and eventually
+# starves the host (recurring "tunnel zombie" pattern).
+#
+# Fix (2026-05-07): drop Node + supergateway, run FastMCP's native
+# streamable-http transport directly. /opt/entrypoint.py monkey-patches
+# FastMCP.__init__ to default streamable_http_path="/", host="0.0.0.0",
+# port=8080, then imports server.py to build the FastMCP instance and calls
+# mcp.run(transport="streamable-http"). Same shape as mcp/warehouse/.
 #
 # A SINGLE image is built from this Dockerfile and reused by both
-# facebook_choiz_mcp and facebook_timeless_mcp services. The two tenants
-# differ only in env vars (FACEBOOK_ACCESS_TOKEN, FACEBOOK_PAGE_ID).
+# facebook_choiz_mcp and facebook_timeless_mcp services. The two tenants differ
+# only in env vars (FACEBOOK_ACCESS_TOKEN, FACEBOOK_PAGE_ID).
 #
-# The SHA below pins the exact build. Bump it intentionally when you want to
-# pick up upstream changes, then push to master — CI/CD rebuilds and deploys.
+# The SHA below pins the exact build of the user-facing fork. Bump it when you
+# want to pick up upstream changes; CI/CD rebuilds and redeploys.
 
 FROM python:3.12-slim
 
 ARG FACEBOOK_MCP_SHA=6418c71de0fa0fec69667cb51583e7bbaed52a05
 
-# git: fetch source at build time.
-# nodejs/npm: install supergateway (the stdio <-> Streamable HTTP bridge).
-# ca-certificates: HTTPS to graph.facebook.com.
+# git: fetch source at build time. ca-certificates: HTTPS to graph.facebook.com.
 RUN apt-get update \
- && apt-get install -y --no-install-recommends git ca-certificates nodejs npm \
+ && apt-get install -y --no-install-recommends git ca-certificates \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -29,31 +39,21 @@ WORKDIR /app
 RUN git clone https://github.com/Choizapp/choiz-facebook-mcp.git . \
  && git checkout "${FACEBOOK_MCP_SHA}"
 
-# Upstream requirements.txt has bare `mcp`; we explicitly install mcp[cli]
-# because server.py does NOT call mcp.run() — it only defines the FastMCP
-# instance and registers tools. The `mcp` CLI (provided by the [cli] extra)
-# loads server.py and starts the stdio transport itself, equivalent to the
-# user's local `uv run mcp run server.py` setup.
-RUN pip install --no-cache-dir "mcp[cli]" requests python-dotenv
+# mcp pinned to 1.25.0 (same minor as warehouse) so the monkey-patched
+# FastMCP.__init__ signature stays predictable. requests + python-dotenv are
+# the fork's runtime deps (its requirements.txt lists them as bare names).
+# We no longer need the [cli] extra: the previous image used `mcp run` to load
+# server.py over stdio; entrypoint.py imports it directly now.
+RUN pip install --no-cache-dir 'mcp==1.25.0' requests python-dotenv
 
-# supergateway bridges stdio <-> Streamable HTTP (same wrapper used by meta-ads).
-RUN npm install -g supergateway
-
-# Disable Python stdio buffering globally so supergateway sees the MCP's
-# initial handshake immediately. The `mcp` CLI subprocess inherits this.
+# Flush stdout immediately so init logs land in `docker logs` without delay.
 ENV PYTHONUNBUFFERED=1
+
+COPY entrypoint.py /opt/entrypoint.py
 
 EXPOSE 8080
 
-# `mcp run server.py` is the launcher: it imports server.py, finds the
-# FastMCP instance, and serves it over stdio. supergateway captures that
-# stdio and exposes it as Streamable HTTP on :8080.
-# --streamableHttpPath / matters: the gateway strips /mcp/<name> before
-# forwarding, so the upstream must serve at /.
-ENTRYPOINT ["supergateway"]
-CMD [ \
-  "--stdio", "mcp run /app/server.py", \
-  "--outputTransport", "streamableHttp", \
-  "--port", "8080", \
-  "--streamableHttpPath", "/" \
-]
+# entrypoint.py applies the FastMCP monkey-patch BEFORE importing server.py,
+# then runs the streamable-http transport in-process. No supergateway hop, no
+# Node, no child-process churn.
+ENTRYPOINT ["python", "/opt/entrypoint.py"]

--- a/mcp/facebook/entrypoint.py
+++ b/mcp/facebook/entrypoint.py
@@ -1,0 +1,55 @@
+"""Facebook MCP entrypoint — serves FastMCP via streamable-http directly.
+
+Mirror of mcp/warehouse/entrypoint.py. See that file's module docstring for the
+full rationale; the short version is:
+
+  - FastMCP (mcp 1.25.0) hard-codes ``streamable_http_path: str = "/mcp"`` and
+    ``host: str = "127.0.0.1"`` as kwarg defaults in ``__init__``. Those kwarg
+    defaults beat env vars in pydantic-settings, so we cannot configure the
+    path/host through the environment.
+  - We must NOT subclass FastMCP — it is ``Generic[LifespanResultT]`` and a
+    plain subclass breaks generic parameterisation, crashing forward-ref
+    resolution at runtime (validated and reverted in PR #8).
+  - Therefore we monkey-patch ``FastMCP.__init__`` in place before importing
+    the user's ``server.py``.
+
+The fork's server.py only does ``mcp = FastMCP("FacebookMCP")`` and registers
+tools with @mcp.tool(); it never calls ``mcp.run()``. The previous image
+launched it through ``supergateway --stdio "mcp run /app/server.py"``, which
+caused a child-process leak under load (supergateway --stateless spawns a
+Python child per request and never reaps them). We now import the FastMCP
+instance directly and run it via streamable-http.
+"""
+from __future__ import annotations
+
+import sys
+
+import mcp.server.fastmcp as _fastmcp_pkg
+
+_orig_init = _fastmcp_pkg.FastMCP.__init__
+
+
+def _patched_init(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+    # Path "/" so the gateway (which strips /mcp/<slug>) reaches the server
+    # without a 307 redirect.
+    kwargs.setdefault("streamable_http_path", "/")
+    # Host 0.0.0.0 disables FastMCP's auto DNS-rebinding protection, which
+    # otherwise rejects the "facebook_<tenant>_mcp:8080" Host header that
+    # http-proxy-middleware (changeOrigin: true) sends → HTTP 421.
+    kwargs.setdefault("host", "0.0.0.0")
+    # Listen on 8080 to match the gateway's UPSTREAM_FACEBOOK_* URLs.
+    kwargs.setdefault("port", 8080)
+    _orig_init(self, *args, **kwargs)
+
+
+_fastmcp_pkg.FastMCP.__init__ = _patched_init  # type: ignore[method-assign]
+
+# /app holds the cloned fork; make it importable regardless of CWD.
+sys.path.insert(0, "/app")
+
+# Import for side effect: builds the FastMCP instance and registers tools.
+from server import mcp  # noqa: E402
+
+
+if __name__ == "__main__":
+    mcp.run(transport="streamable-http")


### PR DESCRIPTION
## Summary

Replicates the warehouse migration (PRs #5/#9/#10) on the facebook MCP image. supergateway in \`--stateless\` mode spawns a Python child per request and never reaps them; under sustained load the container's RAM grows indefinitely and eventually starves the host (recurring \"tunnel zombie\" pattern). Fix swaps the stdio→HTTP bridge for FastMCP's native streamable-http transport.

## Changes

- \`mcp/facebook/entrypoint.py\` (new) — monkey-patches \`FastMCP.__init__\` **in place** (no subclass — that breaks \`Generic[LifespanResultT]\`, validated and reverted in #8) to default \`streamable_http_path=\"/\"\`, \`host=\"0.0.0.0\"\`, \`port=8080\`. Then \`from server import mcp\` builds the FastMCP instance and we call \`mcp.run(transport=\"streamable-http\")\`.
- \`mcp/facebook/Dockerfile\` — drop \`nodejs npm\` + \`npm install -g supergateway\`. Drop \`mcp[cli]\` extra (the CLI was only needed for \`mcp run\` over stdio). Pin \`mcp==1.25.0\` to match warehouse so the monkey-patched signature stays predictable. ENTRYPOINT now \`python /opt/entrypoint.py\`.
- Fork SHA unchanged (\`6418c71de0fa0fec69667cb51583e7bbaed52a05\`).

Single image still serves both \`facebook_choiz_mcp\` and \`facebook_timeless_mcp\`; tenants differ only in env vars.

## Test plan

- [ ] CI builds the ARM64 image successfully on this PR.
- [ ] On EC2, pull the PR-tagged image and \`docker run\` it in isolation (separate from the live stack) with \`FACEBOOK_ACCESS_TOKEN\` + \`FACEBOOK_PAGE_ID\` env vars.
- [ ] \`curl\` the standard smoke test (POST initialize → expect HTTP 200, \`text/event-stream\`, \`mcp-session-id\` header).
- [ ] Inspect container processes: \`docker exec\` and confirm a single \`python /opt/entrypoint.py\` process, no Node, no supergateway children.
- [ ] After merge: claude.ai connector test on facebook-choiz + facebook-timeless to confirm tools still respond.

🤖 Generated with [Claude Code](https://claude.com/claude-code)