### PR TITLE
fix(instagram): drop supergateway, serve lowlevel Server via streamable-http

### DIFF
--- a/mcp/facebook/Dockerfile
+++ b/mcp/facebook/Dockerfile
@@ -2,26 +2,36 @@
 #
 # Source: https://github.com/Choizapp/choiz-facebook-mcp (Choiz fork of
 # HagaiHen/facebook-mcp-server with Graph API v23 + deprecated-metric fixes).
-# Stack: Python (server.py uses mcp[cli] with stdio transport).
-# We wrap it with supergateway so the container exposes MCP Streamable HTTP
-# on :8080, which is what claude.ai speaks.
+# Stack: Python (server.py registers tools on a FastMCP instance — it does NOT
+# call mcp.run()).
+#
+# History: previously bundled Node + supergateway to translate the MCP's stdio
+# transport (via `mcp run /app/server.py`) into MCP Streamable HTTP. The same
+# child-process leak that hit warehouse_mcp on 2026-05-06 affects this image
+# too: supergateway --stateless spawns a Python child per request and never
+# reaps them, so RAM grows indefinitely under sustained load and eventually
+# starves the host (recurring "tunnel zombie" pattern).
+#
+# Fix (2026-05-07): drop Node + supergateway, run FastMCP's native
+# streamable-http transport directly. /opt/entrypoint.py monkey-patches
+# FastMCP.__init__ to default streamable_http_path="/", host="0.0.0.0",
+# port=8080, then imports server.py to build the FastMCP instance and calls
+# mcp.run(transport="streamable-http"). Same shape as mcp/warehouse/.
 #
 # A SINGLE image is built from this Dockerfile and reused by both
-# facebook_choiz_mcp and facebook_timeless_mcp services. The two tenants
-# differ only in env vars (FACEBOOK_ACCESS_TOKEN, FACEBOOK_PAGE_ID).
+# facebook_choiz_mcp and facebook_timeless_mcp services. The two tenants differ
+# only in env vars (FACEBOOK_ACCESS_TOKEN, FACEBOOK_PAGE_ID).
 #
-# The SHA below pins the exact build. Bump it intentionally when you want to
-# pick up upstream changes, then push to master — CI/CD rebuilds and deploys.
+# The SHA below pins the exact build of the user-facing fork. Bump it when you
+# want to pick up upstream changes; CI/CD rebuilds and redeploys.
 
 FROM python:3.12-slim
 
 ARG FACEBOOK_MCP_SHA=6418c71de0fa0fec69667cb51583e7bbaed52a05
 
-# git: fetch source at build time.
-# nodejs/npm: install supergateway (the stdio <-> Streamable HTTP bridge).
-# ca-certificates: HTTPS to graph.facebook.com.
+# git: fetch source at build time. ca-certificates: HTTPS to graph.facebook.com.
 RUN apt-get update \
- && apt-get install -y --no-install-recommends git ca-certificates nodejs npm \
+ && apt-get install -y --no-install-recommends git ca-certificates \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -29,31 +39,21 @@ WORKDIR /app
 RUN git clone https://github.com/Choizapp/choiz-facebook-mcp.git . \
  && git checkout "${FACEBOOK_MCP_SHA}"
 
-# Upstream requirements.txt has bare `mcp`; we explicitly install mcp[cli]
-# because server.py does NOT call mcp.run() — it only defines the FastMCP
-# instance and registers tools. The `mcp` CLI (provided by the [cli] extra)
-# loads server.py and starts the stdio transport itself, equivalent to the
-# user's local `uv run mcp run server.py` setup.
-RUN pip install --no-cache-dir "mcp[cli]" requests python-dotenv
+# mcp pinned to 1.25.0 (same minor as warehouse) so the monkey-patched
+# FastMCP.__init__ signature stays predictable. requests + python-dotenv are
+# the fork's runtime deps (its requirements.txt lists them as bare names).
+# We no longer need the [cli] extra: the previous image used `mcp run` to load
+# server.py over stdio; entrypoint.py imports it directly now.
+RUN pip install --no-cache-dir 'mcp==1.25.0' requests python-dotenv
 
-# supergateway bridges stdio <-> Streamable HTTP (same wrapper used by meta-ads).
-RUN npm install -g supergateway
-
-# Disable Python stdio buffering globally so supergateway sees the MCP's
-# initial handshake immediately. The `mcp` CLI subprocess inherits this.
+# Flush stdout immediately so init logs land in `docker logs` without delay.
 ENV PYTHONUNBUFFERED=1
+
+COPY entrypoint.py /opt/entrypoint.py
 
 EXPOSE 8080
 
-# `mcp run server.py` is the launcher: it imports server.py, finds the
-# FastMCP instance, and serves it over stdio. supergateway captures that
-# stdio and exposes it as Streamable HTTP on :8080.
-# --streamableHttpPath / matters: the gateway strips /mcp/<name> before
-# forwarding, so the upstream must serve at /.
-ENTRYPOINT ["supergateway"]
-CMD [ \
-  "--stdio", "mcp run /app/server.py", \
-  "--outputTransport", "streamableHttp", \
-  "--port", "8080", \
-  "--streamableHttpPath", "/" \
-]
+# entrypoint.py applies the FastMCP monkey-patch BEFORE importing server.py,
+# then runs the streamable-http transport in-process. No supergateway hop, no
+# Node, no child-process churn.
+ENTRYPOINT ["python", "/opt/entrypoint.py"]

--- a/mcp/facebook/entrypoint.py
+++ b/mcp/facebook/entrypoint.py
@@ -1,0 +1,55 @@
+"""Facebook MCP entrypoint — serves FastMCP via streamable-http directly.
+
+Mirror of mcp/warehouse/entrypoint.py. See that file's module docstring for the
+full rationale; the short version is:
+
+  - FastMCP (mcp 1.25.0) hard-codes ``streamable_http_path: str = "/mcp"`` and
+    ``host: str = "127.0.0.1"`` as kwarg defaults in ``__init__``. Those kwarg
+    defaults beat env vars in pydantic-settings, so we cannot configure the
+    path/host through the environment.
+  - We must NOT subclass FastMCP — it is ``Generic[LifespanResultT]`` and a
+    plain subclass breaks generic parameterisation, crashing forward-ref
+    resolution at runtime (validated and reverted in PR #8).
+  - Therefore we monkey-patch ``FastMCP.__init__`` in place before importing
+    the user's ``server.py``.
+
+The fork's server.py only does ``mcp = FastMCP("FacebookMCP")`` and registers
+tools with @mcp.tool(); it never calls ``mcp.run()``. The previous image
+launched it through ``supergateway --stdio "mcp run /app/server.py"``, which
+caused a child-process leak under load (supergateway --stateless spawns a
+Python child per request and never reaps them). We now import the FastMCP
+instance directly and run it via streamable-http.
+"""
+from __future__ import annotations
+
+import sys
+
+import mcp.server.fastmcp as _fastmcp_pkg
+
+_orig_init = _fastmcp_pkg.FastMCP.__init__
+
+
+def _patched_init(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+    # Path "/" so the gateway (which strips /mcp/<slug>) reaches the server
+    # without a 307 redirect.
+    kwargs.setdefault("streamable_http_path", "/")
+    # Host 0.0.0.0 disables FastMCP's auto DNS-rebinding protection, which
+    # otherwise rejects the "facebook_<tenant>_mcp:8080" Host header that
+    # http-proxy-middleware (changeOrigin: true) sends → HTTP 421.
+    kwargs.setdefault("host", "0.0.0.0")
+    # Listen on 8080 to match the gateway's UPSTREAM_FACEBOOK_* URLs.
+    kwargs.setdefault("port", 8080)
+    _orig_init(self, *args, **kwargs)
+
+
+_fastmcp_pkg.FastMCP.__init__ = _patched_init  # type: ignore[method-assign]
+
+# /app holds the cloned fork; make it importable regardless of CWD.
+sys.path.insert(0, "/app")
+
+# Import for side effect: builds the FastMCP instance and registers tools.
+from server import mcp  # noqa: E402
+
+
+if __name__ == "__main__":
+    mcp.run(transport="streamable-http")

--- a/mcp/instagram/Dockerfile
+++ b/mcp/instagram/Dockerfile
@@ -4,30 +4,40 @@
 # jlbadano/ig-mcp with Graph API v23 metric updates: 'impressions' is
 # deprecated in v22+, replaced by 'views'; 'follows' and 'total_interactions'
 # added).
-# Stack: Python; src/instagram_mcp_server.py uses the low-level mcp.server.Server
-# (NOT FastMCP) and runs its own asyncio.run(main()) on stdio. Tools return
-# Sequence[TextContent], so the str-return primitive bug we hit on facebook
-# does NOT apply here.
-# We wrap with supergateway so the container exposes MCP Streamable HTTP on
-# :8080, which is what claude.ai speaks.
+# Stack: Python; src/instagram_mcp_server.py uses the low-level
+# mcp.server.lowlevel.Server (NOT FastMCP). Tools return Sequence[TextContent],
+# so the str-return primitive bug we hit on facebook does NOT apply here.
+#
+# History: previously bundled Node + supergateway to translate the MCP's
+# stdio transport into MCP Streamable HTTP. Same supergateway --stateless
+# leak that hit warehouse (2026-05-06) and facebook (2026-05-07): each
+# request spawned a fresh Python child that was never reaped, so RAM grew
+# indefinitely. Pre-fix observation on 2026-05-07: instagram_choiz_mcp at
+# 2.1 GB resident with no memlimit.
+#
+# Fix (2026-05-07): drop Node + supergateway, serve the lowlevel Server
+# directly through MCP's StreamableHTTPSessionManager. /opt/entrypoint.py
+# instantiates InstagramMCPServer (which registers all tools on its inner
+# .server), mounts that Server behind the session manager, wraps it in a
+# Starlette app and runs it under uvicorn. Same end result as warehouse and
+# facebook (single Python process, no per-request child churn) via a
+# different code path because the fork doesn't use FastMCP.
 #
 # A SINGLE image is built from this Dockerfile and reused by both
 # instagram_choiz_mcp and instagram_timeless_mcp services. The two tenants
 # differ only in env vars (INSTAGRAM_ACCESS_TOKEN, INSTAGRAM_BUSINESS_ACCOUNT_ID).
 # FACEBOOK_APP_ID / FACEBOOK_APP_SECRET are shared (one Choiz Facebook app).
 #
-# The SHA below pins the exact build. Bump it intentionally when you want to
-# pick up upstream changes, then push to master — CI/CD rebuilds and deploys.
+# Bump the SHA below to pick up upstream fork changes; CI/CD rebuilds and
+# redeploys.
 
 FROM python:3.12-slim
 
 ARG INSTAGRAM_MCP_SHA=1c01c4d3b001b9d3b147f58ef948a2bba11cbdf9
 
-# git: fetch source at build time.
-# nodejs/npm: install supergateway (the stdio <-> Streamable HTTP bridge).
-# ca-certificates: HTTPS to graph.facebook.com.
+# git: fetch source at build time. ca-certificates: HTTPS to graph.facebook.com.
 RUN apt-get update \
- && apt-get install -y --no-install-recommends git ca-certificates nodejs npm \
+ && apt-get install -y --no-install-recommends git ca-certificates \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -35,31 +45,23 @@ WORKDIR /app
 RUN git clone https://github.com/Choizapp/choiz-instagram-mcp.git . \
  && git checkout "${INSTAGRAM_MCP_SHA}"
 
-# Upstream pins all runtime deps in requirements.txt (mcp, fastmcp, httpx,
-# pydantic, pydantic-settings, structlog, etc). Keeping the install verbatim
-# so we don't drift from what the fork's authors test against.
-RUN pip install --no-cache-dir -r requirements.txt
+# Install the fork's deps as-pinned (httpx, pydantic, structlog, ...). The
+# fork's requirements.txt has bare `mcp>=1.0.0`, so we re-pin afterwards to
+# 1.25.0 (matches warehouse + facebook) for reproducible behaviour of
+# StreamableHTTPSessionManager. starlette + uvicorn are needed by our
+# entrypoint to host the MCP session manager as an ASGI app.
+RUN pip install --no-cache-dir -r requirements.txt \
+ && pip install --no-cache-dir 'mcp==1.25.0' 'uvicorn[standard]' starlette
 
-# supergateway bridges stdio <-> Streamable HTTP (same wrapper used by facebook/meta-ads).
-RUN npm install -g supergateway
-
-# Disable Python stdio buffering so supergateway sees the MCP's initial
-# handshake immediately. Critical for the Streamable HTTP wrapper.
+# Flush stdout immediately so init logs land in `docker logs` without delay.
 ENV PYTHONUNBUFFERED=1
+
+COPY entrypoint.py /opt/entrypoint.py
 
 EXPOSE 8080
 
-# `python -m src.instagram_mcp_server` is the launcher: the module's __main__
-# block runs asyncio.run(main()) which starts the stdio_server. supergateway
-# captures that stdio and exposes it as Streamable HTTP on :8080.
-# (Different from facebook, which uses `mcp run` because its server.py only
-# defines the FastMCP instance without calling .run() itself.)
-# --streamableHttpPath / matters: the gateway strips /mcp/<name> before
-# forwarding, so the upstream must serve at /.
-ENTRYPOINT ["supergateway"]
-CMD [ \
-  "--stdio", "python -m src.instagram_mcp_server", \
-  "--outputTransport", "streamableHttp", \
-  "--port", "8080", \
-  "--streamableHttpPath", "/" \
-]
+# entrypoint.py instantiates InstagramMCPServer (registers tools on its
+# inner lowlevel Server), mounts it behind StreamableHTTPSessionManager and
+# serves at "/" via uvicorn. No supergateway, no Node, no per-request
+# child spawning.
+ENTRYPOINT ["python", "/opt/entrypoint.py"]

--- a/mcp/instagram/entrypoint.py
+++ b/mcp/instagram/entrypoint.py
@@ -1,0 +1,120 @@
+"""Instagram MCP entrypoint — serves the lowlevel Server via streamable-http.
+
+The fork (Choizapp/choiz-instagram-mcp) uses ``mcp.server.lowlevel.Server``
+directly — NOT FastMCP. ``InstagramMCPServer.run()`` hardcodes a
+``stdio_server()`` context manager. The previous image worked around that by
+wrapping the stdio server in supergateway, which spawns a fresh Python child
+per request and never reaps them; sustained load grew this container to ~2 GB
+(observed 2026-05-07 pre-fix). This is the same leak we removed from
+warehouse and facebook.
+
+Migration shape (different from warehouse/facebook because there is no
+FastMCP to monkey-patch):
+
+  1. Instantiate ``InstagramMCPServer()`` — this registers all tools on its
+     internal ``.server`` (a ``mcp.server.lowlevel.Server`` instance).
+  2. Mount that ``.server`` behind ``StreamableHTTPSessionManager`` (the same
+     transport-layer manager FastMCP uses internally).
+  3. Wrap with a Starlette app that delegates "/" to the session manager and
+     enters the manager's lifespan in ``async with``.
+  4. Serve with uvicorn on 0.0.0.0:8080.
+
+No monkey-patch is needed: we construct the session manager directly and pin
+the path/host/port in this file.
+
+We replicate the fork's structlog config so log output matches what the
+authors test against (the fork's main() does this before calling
+InstagramMCPServer().run()).
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import sys
+
+import structlog
+import uvicorn
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+from starlette.applications import Starlette
+from starlette.routing import Mount
+
+# Make /app and /app/src importable regardless of CWD.
+sys.path.insert(0, "/app")
+sys.path.insert(0, "/app/src")
+
+# Imported for the side effect of building the InstagramMCPServer class.
+from instagram_mcp_server import InstagramMCPServer, get_settings  # noqa: E402
+
+
+def _configure_logging() -> None:
+    """Mirror the fork's main() logging setup so output stays compatible."""
+    structlog.configure(
+        processors=[
+            structlog.stdlib.filter_by_level,
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.processors.UnicodeDecoder(),
+            structlog.processors.JSONRenderer(),
+        ],
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+    settings = get_settings()
+    logging.basicConfig(level=getattr(logging, settings.log_level))
+
+
+async def _serve() -> None:
+    _configure_logging()
+
+    instagram = InstagramMCPServer()  # registers tools on instagram.server
+
+    # stateless=False keeps SDK-level sessions across requests. This is NOT
+    # the supergateway --stateful flag (which trips bug #126 under claude.ai
+    # — see project_supergateway_stateful_bug126.md). The MCP SDK's session
+    # manager handles claude.ai's parallel POST + GET SSE streams correctly
+    # at the protocol layer; the supergateway bug was specific to
+    # supergateway's bridging logic, not the spec.
+    session_manager = StreamableHTTPSessionManager(
+        app=instagram.server,
+        event_store=None,
+        json_response=False,
+        stateless=False,
+    )
+
+    async def asgi_handler(scope, receive, send):  # type: ignore[no-untyped-def]
+        await session_manager.handle_request(scope, receive, send)
+
+    @contextlib.asynccontextmanager
+    async def lifespan(app):  # type: ignore[no-untyped-def]
+        async with session_manager.run():
+            yield
+
+    # Mount at "/" — the gateway strips /mcp/<slug> before forwarding, so the
+    # upstream must serve at root.
+    app = Starlette(
+        routes=[Mount("/", app=asgi_handler)],
+        lifespan=lifespan,
+    )
+
+    # Host 0.0.0.0 so docker bridge networking works; port 8080 matches the
+    # gateway's UPSTREAM_INSTAGRAM_* URLs.
+    config = uvicorn.Config(
+        app,
+        host="0.0.0.0",
+        port=8080,
+        log_level="info",
+        access_log=False,
+    )
+    server = uvicorn.Server(config)
+    await server.serve()
+
+
+if __name__ == "__main__":
+    asyncio.run(_serve())


### PR DESCRIPTION
## Summary

Phase 1.2 of the supergateway eviction. Instagram pre-fix was at **2.1 GB resident** with no memlimit (observed 2026-05-07) — same supergateway --stateless leak that hit warehouse (PRs #5/#9/#10) and facebook (#11).

Different from facebook: the fork uses \`mcp.server.lowlevel.Server\` directly (not FastMCP), so the FastMCP \`__init__\` monkey-patch does NOT apply. Instead, the entrypoint builds the streamable-http stack manually with the SDK's \`StreamableHTTPSessionManager\` + Starlette + uvicorn.

## Changes

- \`mcp/instagram/entrypoint.py\` (new):
  - Instantiate \`InstagramMCPServer\` (registers tools on its inner \`Server\`).
  - Mount the lowlevel \`Server\` behind \`StreamableHTTPSessionManager(json_response=False, stateless=False)\`. This is SDK-level state — NOT the supergateway \`--stateful\` flag tripped by bug #126; the MCP spec session manager handles claude.ai's parallel POST + GET SSE streams correctly.
  - Wrap as a Starlette app at \`/\` with the manager's lifespan.
  - Serve under uvicorn on \`0.0.0.0:8080\`.
  - Replicates the fork's structlog + log-level setup so output stays compatible.
- \`mcp/instagram/Dockerfile\`:
  - Drop nodejs/npm + supergateway.
  - \`pip install -r requirements.txt\` (preserves fork's pinned deps), then re-pin \`mcp==1.25.0\` and add \`uvicorn[standard]\` + \`starlette\` (needed for ASGI hosting).
  - ENTRYPOINT: \`python /opt/entrypoint.py\`.
- Fork SHA unchanged (\`1c01c4d3b001b9d3b147f58ef948a2bba11cbdf9\`).

Single image still serves both \`instagram_choiz_mcp\` and \`instagram_timeless_mcp\`.

## Test plan

- [ ] CI builds the ARM64 image successfully.
- [ ] SSM smoke-test: POST initialize to both slugs → HTTP 200, \`text/event-stream\`, valid JSON-RPC.
- [ ] \`docker compose exec\` confirms PID 1 = \`python /opt/entrypoint.py\`, no Node, no supergateway.
- [ ] \`docker stats\` post-deploy: instagram containers should drop from 2.1 GB → ~50-150 MB resident.
- [ ] After merge: claude.ai connector test on instagram-choiz + instagram-timeless to confirm tools still respond (especially \`get_media_posts\`, \`get_profile_info\` — pre-existing payload-shrink fix is fork-side, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)