### PR TITLE
feat(ga4): switch to official googleanalytics/google-analytics-mcp

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -119,38 +119,34 @@ services:
       INSTAGRAM_API_VERSION: "v23.0"
     restart: unless-stopped
 
-  # GA4 MCP — multi-tenant pattern, mirroring facebook/instagram. One
-  # image, two containers, distinguished only by GA4_PROPERTY_ID. The
-  # service-account JSON (GA4_SERVICE_ACCOUNT_JSON_B64) is shared between
-  # tenants (single Choiz reader account).
+  # GA4 MCP — official googleanalytics/google-analytics-mcp wrapped in
+  # streamable-http. Multi-tenant pattern: one image, two containers
+  # serving slugs /mcp/ga4-choiz and /mcp/ga4-timeless. Both containers
+  # are functionally identical — the official MCP takes property_id as
+  # a TOOL ARGUMENT (not an env var), so the model passes the right
+  # property per call. The two containers exist purely so claude.ai
+  # connectors stay separated by brand at the slug level (same pattern
+  # as gsc).
   #
-  # Wraps the choiz-ga4-mcp Python server with `supergateway --stateful`.
-  # Stateful is mandatory here: this MCP wraps the google-analytics-data
-  # gRPC SDK, which is the same family that destabilized the cloudflared
-  # tunnel under google-ads on 2026-04-28 when run under default stateless
-  # mode. Stateful keeps one warm gRPC client per session instead of
-  # respawning the python child per request.
+  # Service-account JSON (GA4_SERVICE_ACCOUNT_JSON_B64) is shared between
+  # tenants (single Choiz reader account with access to both Choiz +
+  # Timeless GA4 properties).
   #
-  # mem_limit + pids_limit retained as defense-in-depth against open bugs
-  # in supergateway stateful mode (#124 child-process leak, #126
-  # SIGTERM-on-reconnect). If a leak appears, the container OOMs cleanly
-  # and restarts.
+  # Cutover 2026-05-07 (PR #14): replaced the Choiz fork
+  # (Choizapp/choiz-ga4-mcp@a0278ff) and dropped supergateway. The
+  # official MCP uses mcp.server.lowlevel.Server with hardcoded stdio;
+  # mcp/ga4/entrypoint.py mounts it behind StreamableHTTPSessionManager
+  # + uvicorn. Same shape as instagram (PR #12 + #13).
   #
-  # Bumped 800m → 1500m on 2026-04-30: when claude.ai loads multiple
-  # connectors in parallel (user adding a connector or refreshing the
-  # session) supergateway --stateless spawns several python children
-  # carrying the heavy google-analytics-data gRPC stack at once. Under
-  # the old 800m limit the cgroup OOMed and supergateway exited code
-  # 137; the user-visible symptom was "Authorization with the MCP
-  # server failed" in claude.ai. The host now has a 4 GB swapfile that
-  # absorbs host-level pressure (vm.swappiness=10), so we no longer
-  # need such a tight per-container fence. See host-snapshot logs
-  # 2026-04-30 14:35-14:49 UTC for the spike + recovery pattern.
+  # mem_limit retained at 1500m as defense-in-depth pending
+  # post-deploy measurement. The single-process pattern that landed
+  # warehouse + facebook + instagram drops resident from ~1 GB to
+  # ~50-150 MB, so this cap is likely loose; revisit after a stress
+  # test.
   ga4_choiz_mcp:
     image: ghcr.io/choizapp/choiz-mcp-gateway/ga4:${IMAGE_TAG:-latest}
     environment:
       GA4_SERVICE_ACCOUNT_JSON_B64: ${GA4_SERVICE_ACCOUNT_JSON_B64:?set GA4_SERVICE_ACCOUNT_JSON_B64 in .env}
-      GA4_PROPERTY_ID: ${GA4_CHOIZ_PROPERTY_ID:?set GA4_CHOIZ_PROPERTY_ID in .env}
     mem_limit: 1500m
     pids_limit: 100
     restart: unless-stopped
@@ -159,7 +155,6 @@ services:
     image: ghcr.io/choizapp/choiz-mcp-gateway/ga4:${IMAGE_TAG:-latest}
     environment:
       GA4_SERVICE_ACCOUNT_JSON_B64: ${GA4_SERVICE_ACCOUNT_JSON_B64:?set GA4_SERVICE_ACCOUNT_JSON_B64 in .env}
-      GA4_PROPERTY_ID: ${GA4_TIMELESS_PROPERTY_ID:?set GA4_TIMELESS_PROPERTY_ID in .env}
     mem_limit: 1500m
     pids_limit: 100
     restart: unless-stopped

--- a/mcp/ga4/Dockerfile
+++ b/mcp/ga4/Dockerfile
@@ -1,101 +1,61 @@
-# GA4 MCP — Google Analytics 4 reporting (run_report, schema browsing).
+# GA4 MCP — Google Analytics 4 reporting (run_report, run_funnel_report,
+# get_account_summaries, get_property_details, run_realtime_report,
+# get_custom_dimensions_and_metrics, list_google_ads_links).
 #
-# Source: https://github.com/Choizapp/choiz-ga4-mcp (Choiz fork, Google
-# Analytics 4 reporting on top of google-analytics-data v1beta).
+# Source: https://github.com/googleanalytics/google-analytics-mcp — the
+# **official** Google Analytics MCP, replacing the previous Choiz fork at
+# Choizapp/choiz-ga4-mcp@a0278ff (cutover 2026-05-07).
 #
-# Stack: Python; ga4_mcp/server.py defines a FastMCP instance and calls
-# mcp.run(transport="stdio") at the end of main(). Launcher: `python -m
-# ga4_mcp` — the package's __main__ wires it up.
+# Stack: Python; uses mcp.server.lowlevel.Server with hardcoded stdio
+# transport (analytics_mcp/server.py:run_server_async). We do NOT launch
+# the upstream `analytics-mcp` console script — instead /opt/entrypoint.py
+# imports analytics_mcp.coordinator.app (the Server instance) and serves
+# it directly through StreamableHTTPSessionManager + Starlette + uvicorn.
+# Same shape as mcp/instagram/.
 #
 # Multi-tenant: one image, two service blocks (ga4_choiz, ga4_timeless)
-# differing only in GA4_PROPERTY_ID. Service-account JSON is shared
-# between both tenants.
+# differing only in slug. The official MCP takes property_id as a tool
+# argument (not env), so both tenants point at the same code with the
+# same auth; the model passes the right property_id per call.
 #
-# Auth: service-account JSON. Two ways to get it into the container:
-#   (a) GA4_SERVICE_ACCOUNT_JSON_B64 env var (single-line base64) — what
-#       we use. Entrypoint decodes to /app/sa.json before launching.
-#   (b) Mounted file via Docker secret — rejected as overkill; the env
-#       pattern matches the rest of our MCPs.
+# Auth: GOOGLE_APPLICATION_CREDENTIALS file path. The Choiz reader SA JSON
+# is provided through the GA4_SERVICE_ACCOUNT_JSON_B64 env var; the
+# entrypoint base64-decodes it to /tmp/ga4-sa.json on each container
+# start (not at build time, so the JSON does not bake into the image).
 #
-# We wrap with supergateway (--stateful) so the python child + the
-# gRPC BetaAnalyticsDataClient persist across MCP requests on the same
-# session. The default --stateless mode would respawn the python child
-# per request, importing the heavy google-analytics-data gRPC stack and
-# opening fresh outbound channels each call — same connection-storm
-# pattern that destabilized the cloudflared tunnel under google-ads on
-# 2026-04-28. --stateful sidesteps that.
-#
-# The SHA below pins the exact build. Bump it intentionally when you
-# want to pick up upstream changes; CI/CD rebuilds and deploys.
+# Pin to commit 6fd3bf88 of the upstream main branch for reproducibility.
 
 FROM python:3.12-slim
 
-ARG GA4_MCP_SHA=a0278ff
+ARG GA4_MCP_SHA=6fd3bf88e2591855cf3fade7e3c791e1f6bda72d
 
-# git: clone source at build time.
-# nodejs/npm: install supergateway (the stdio <-> Streamable HTTP bridge).
-# ca-certificates: HTTPS to analyticsdata.googleapis.com (gRPC over TLS).
+# git: pip install from a git URL needs git in the image at install time.
+# ca-certificates: HTTPS to analyticsdata.googleapis.com + GitHub.
+# build-essential: some transitive deps (e.g. grpcio) build wheels on ARM64.
 RUN apt-get update \
- && apt-get install -y --no-install-recommends git ca-certificates nodejs npm \
+ && apt-get install -y --no-install-recommends git ca-certificates build-essential \
  && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /app
+# Install the official MCP from a pinned commit. pyproject.toml registers
+# the analytics_mcp package + console scripts, but we don't use the script
+# (entrypoint.py imports the package directly).
+RUN pip install --no-cache-dir \
+    "git+https://github.com/googleanalytics/google-analytics-mcp.git@${GA4_MCP_SHA}" \
+    "uvicorn[standard]" \
+    starlette
 
-RUN git clone https://github.com/Choizapp/choiz-ga4-mcp.git . \
- && git checkout "${GA4_MCP_SHA}"
+# Strip build deps once wheels are compiled to keep the final layer slim.
+RUN apt-get purge -y --auto-remove build-essential && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir -r requirements.txt
-
-# supergateway bridges stdio <-> Streamable HTTP. --stateful keeps one
-# python child per MCP session (see comment above).
-RUN npm install -g supergateway
-
-# Disable Python stdio buffering so supergateway sees the MCP's initial
-# handshake immediately. Critical for the Streamable HTTP wrapper.
+# Flush stdout immediately so init logs land in `docker logs` without delay.
 ENV PYTHONUNBUFFERED=1
 
-# Default credentials path — set here so the python process picks it up
-# without the entrypoint having to export it.
-ENV GOOGLE_APPLICATION_CREDENTIALS=/app/sa.json
-
-# Custom entrypoint: decodes GA4_SERVICE_ACCOUNT_JSON_B64 to /app/sa.json,
-# then exec's supergateway with the full CMD args. Done at container
-# start (not at build) so the JSON does not bake into the image layer.
-RUN printf '%s\n' \
- '#!/bin/sh' \
- 'set -e' \
- 'if [ -z "${GA4_SERVICE_ACCOUNT_JSON_B64:-}" ]; then' \
- '  echo "ERROR: GA4_SERVICE_ACCOUNT_JSON_B64 not set" >&2' \
- '  exit 1' \
- 'fi' \
- 'echo "$GA4_SERVICE_ACCOUNT_JSON_B64" | base64 -d > /app/sa.json' \
- 'chmod 600 /app/sa.json' \
- 'exec supergateway "$@"' \
- > /entrypoint.sh \
- && chmod +x /entrypoint.sh
+COPY entrypoint.py /opt/entrypoint.py
 
 EXPOSE 8080
 
-# `python -m ga4_mcp` runs ga4_mcp/__main__.py which calls server.main().
-# server.main() calls mcp.run(transport="stdio") on the FastMCP instance.
-# supergateway captures that stdio and exposes it as Streamable HTTP on :8080.
-# --streamableHttpPath / matters: the gateway strips /mcp/<name> before
-# forwarding, so the upstream must serve at /.
-#
-# NOTE: --stateful was tried first (commit before this) on the assumption
-# that the gRPC connection-storm pattern from google-ads would also bite
-# GA4. In practice supergateway's stateful path tripped issue #126
-# ("Conflict: Only one SSE stream is allowed per session") on every
-# claude.ai session, SIGTERMing the python child after ~1 tool call.
-# Reverted to default --stateless. The google-analytics-data SDK is much
-# lighter than google-ads (no protobuf descriptor pool, single channel
-# per request), so the connection-storm hypothesis is unlikely to
-# reproduce. If it does, the auto-reboot escalation in monitor-tunnel.yml
-# will recover the host without manual intervention.
-ENTRYPOINT ["/entrypoint.sh"]
-CMD [ \
-  "--stdio", "python -m ga4_mcp", \
-  "--outputTransport", "streamableHttp", \
-  "--port", "8080", \
-  "--streamableHttpPath", "/" \
-]
+# entrypoint.py decodes GA4_SERVICE_ACCOUNT_JSON_B64 → /tmp/ga4-sa.json,
+# sets GOOGLE_APPLICATION_CREDENTIALS, imports the official package's
+# coordinator.app, and serves it via streamable-http on 0.0.0.0:8080.
+# No supergateway, no Node, no per-request child churn.
+ENTRYPOINT ["python", "/opt/entrypoint.py"]

--- a/mcp/ga4/entrypoint.py
+++ b/mcp/ga4/entrypoint.py
@@ -1,0 +1,112 @@
+"""GA4 MCP entrypoint — official googleanalytics/google-analytics-mcp wrapped
+in streamable-http transport.
+
+Cutover from the previous Choiz fork (Choizapp/choiz-ga4-mcp@a0278ff) to the
+**official** Google Analytics MCP at
+https://github.com/googleanalytics/google-analytics-mcp pinned to commit
+6fd3bf88. The official server uses ``mcp.server.lowlevel.Server`` and a
+hardcoded ``stdio_server()`` transport — the same shape as our instagram
+fork — so the migration shape is the same:
+
+  1. Decode ``GA4_SERVICE_ACCOUNT_JSON_B64`` from env (single Choiz reader
+     SA, shared across tenants) into a JSON file at /tmp/sa.json. Set
+     ``GOOGLE_APPLICATION_CREDENTIALS`` to that path so the
+     google-analytics-data + google-analytics-admin clients pick it up via
+     Application Default Credentials. The base64 form survives the
+     newline-sensitive .env loader.
+  2. Import ``analytics_mcp.server`` to register all @app.tool decorators
+     (run_report, run_funnel_report, get_account_summaries, etc.) on the
+     module-level lowlevel Server at ``analytics_mcp.coordinator.app``.
+  3. Mount that Server behind ``StreamableHTTPSessionManager``.
+  4. Wrap as a Starlette app at "/" with the manager's lifespan.
+  5. Serve under uvicorn on 0.0.0.0:8080.
+
+property_id is now a per-tool argument, not a per-container env. Two
+containers still exist (ga4_choiz_mcp + ga4_timeless_mcp) for slug
+separation; both run the same code with the same auth and just expose
+different routes for connector clarity. The model passes the right
+property_id per call.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import contextlib
+import logging
+import os
+import sys
+
+import uvicorn
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+from starlette.applications import Starlette
+from starlette.routing import Mount
+
+
+def _materialize_service_account() -> None:
+    """Decode the base64 SA JSON env into a file the google-auth lib reads.
+
+    Carries forward the pattern from the previous Choiz fork's entrypoint —
+    this is the cleanest way to inject auth into the host google-auth ADC
+    chain without checking JSON files into the repo.
+    """
+    b64 = os.environ.get("GA4_SERVICE_ACCOUNT_JSON_B64")
+    if not b64:
+        raise RuntimeError(
+            "GA4_SERVICE_ACCOUNT_JSON_B64 env var is required (base64-encoded "
+            "Google service account JSON for the Choiz GA4 reader account)."
+        )
+    sa_path = "/tmp/ga4-sa.json"
+    with open(sa_path, "wb") as f:
+        f.write(base64.b64decode(b64))
+    os.chmod(sa_path, 0o600)
+    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = sa_path
+
+
+async def _serve() -> None:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    _materialize_service_account()
+
+    # Importing analytics_mcp.server runs ``from .coordinator import ...``
+    # which in turn imports all tool modules; their @app.tool decorators
+    # register against the module-level Server. After this import,
+    # analytics_mcp.coordinator.app is fully populated.
+    import analytics_mcp.server  # noqa: F401
+    from analytics_mcp.coordinator import app
+
+    session_manager = StreamableHTTPSessionManager(
+        app=app,
+        event_store=None,
+        json_response=False,
+        stateless=False,
+    )
+
+    async def asgi_handler(scope, receive, send):  # type: ignore[no-untyped-def]
+        await session_manager.handle_request(scope, receive, send)
+
+    @contextlib.asynccontextmanager
+    async def lifespan(app):  # type: ignore[no-untyped-def]
+        async with session_manager.run():
+            yield
+
+    starlette_app = Starlette(
+        routes=[Mount("/", app=asgi_handler)],
+        lifespan=lifespan,
+    )
+
+    config = uvicorn.Config(
+        starlette_app,
+        host="0.0.0.0",
+        port=8080,
+        log_level="info",
+        access_log=False,
+    )
+    server = uvicorn.Server(config)
+    await server.serve()
+
+
+if __name__ == "__main__":
+    asyncio.run(_serve())

--- a/mcp/instagram/entrypoint.py
+++ b/mcp/instagram/entrypoint.py
@@ -39,12 +39,16 @@ from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from starlette.applications import Starlette
 from starlette.routing import Mount
 
-# Make /app and /app/src importable regardless of CWD.
+# Make /app importable so `src` is found as a package. We must NOT add
+# /app/src to sys.path — that would import instagram_mcp_server as a
+# top-level module, breaking its `from .config import get_settings`
+# relative import (ImportError: attempted relative import with no known
+# parent package). The fork's previous launcher `python -m src.instagram_mcp_server`
+# preserved the package context the same way.
 sys.path.insert(0, "/app")
-sys.path.insert(0, "/app/src")
 
 # Imported for the side effect of building the InstagramMCPServer class.
-from instagram_mcp_server import InstagramMCPServer, get_settings  # noqa: E402
+from src.instagram_mcp_server import InstagramMCPServer, get_settings  # noqa: E402
 
 
 def _configure_logging() -> None:


### PR DESCRIPTION
## ⚠️ DO NOT AUTO-MERGE

This PR replaces the Choiz GA4 fork with the **official** Google Analytics MCP. Tool surface changes (\`get_ga4_data\` → \`run_report\`/\`run_funnel_report\`/etc.) which means existing skills (\`ga4-funnel-choiz\`, \`ga4-funnel-timeless\`, \`blog-analyst\`) likely need updates. Validate from claude.ai first.

## Summary

Cutover from \`Choizapp/choiz-ga4-mcp@a0278ff\` to \`googleanalytics/google-analytics-mcp@6fd3bf88\` (the official MCP from the GA team). Same migration shape as instagram PR #12 + #13 — the official server is stdio-only on \`mcp.server.lowlevel.Server\`, so we wrap with \`StreamableHTTPSessionManager\` + Starlette + uvicorn.

## Why now

1. The Choiz fork was custom-maintained for a tool surface we no longer need to invent — the official has equivalent semantics with maintained authoritative semantics.
2. Same supergateway leak as facebook + instagram: ga4_choiz_mcp was at 953 MiB / 1.5 GB cap pre-fix.
3. Eliminates Node + supergateway + per-request child churn for GA4.

## Changes

- \`mcp/ga4/Dockerfile\`: install official MCP from pinned commit, drop fork + Node + supergateway, add ASGI host deps. Strip build-essential after wheels compile.
- \`mcp/ga4/entrypoint.py\` (new): decode SA JSON env → file, set \`GOOGLE_APPLICATION_CREDENTIALS\`, import \`analytics_mcp.server\` (registers tools on \`coordinator.app\`), mount that Server behind \`StreamableHTTPSessionManager\` + Starlette + uvicorn.
- \`compose.yml\`: drop \`GA4_PROPERTY_ID\` env vars (official MCP takes property_id as tool arg). Both containers stay (slug-only separation, gsc-style). \`mem_limit: 1500m\` retained for now — likely loose, revisit after stress test.

## Tool surface delta (Choiz fork → official)

| Old (Choiz fork) | New (official) |
|---|---|
| \`get_ga4_data\` (free-form dimensions/metrics) | \`run_report\` |
| n/a | \`run_funnel_report\` |
| \`get_property_schema\` | \`get_property_details\` |
| \`list_metric_categories\`, \`list_dimension_categories\`, \`get_metrics_by_category\`, \`get_dimensions_by_category\` | \`get_custom_dimensions_and_metrics\` (different shape) |
| n/a | \`get_account_summaries\` |
| n/a | \`run_realtime_report\` |
| n/a | \`list_google_ads_links\` |

## Test plan

- [ ] CI builds the ARM64 image successfully.
- [ ] SSM smoke-test: POST initialize to both \`/mcp/ga4-choiz\` and \`/mcp/ga4-timeless\` → HTTP 200, \`text/event-stream\`, valid JSON-RPC.
- [ ] \`docker compose exec\` confirms PID 1 = \`python /opt/entrypoint.py\`, no Node, no supergateway.
- [ ] \`docker stats\` post-deploy: ga4 containers should drop from ~950 MB → ~100-200 MB resident.
- [ ] **CLAUDE.AI VALIDATION REQUIRED**: re-add the ga4-choiz / ga4-timeless connectors and confirm tools list shows the official names. Try one \`run_report\` call to a known property to confirm auth + payload shape work end-to-end.
- [ ] **Skills audit (out of repo)**: review \`anthropic-skills/ga4-funnel-choiz\`, \`ga4-funnel-timeless\`, \`blog-analyst\` and adapt them to the new tool names if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)