### PR TITLE
fix(google-ads): use ADC authorized_user JSON for static refresh-token auth

### DIFF
--- a/mcp/google-ads/entrypoint.py
+++ b/mcp/google-ads/entrypoint.py
@@ -1,81 +1,84 @@
 """Google Ads MCP entrypoint — official googleads/google-ads-mcp wrapped in
-streamable-http with static creds.
+streamable-http with static OAuth user creds via ADC "authorized_user" JSON.
 
 Cutover from the previous Choiz fork (Choizapp/choiz-google-ads-mcp@6fefe68,
 disabled 2026-04-28 due to tunnel-zombie pattern under supergateway --stateless)
 to the official MCP at https://github.com/googleads/google-ads-mcp pinned to
 commit 2a09ac31.
 
-Key architectural points:
+Auth (the tricky part):
+  The official MCP's `ads_mcp/utils.py:_create_credentials()` only supports
+  two paths:
+    1. FastMCP's `get_access_token()` (active only when the OAuth Proxy
+       is configured via GOOGLE_ADS_MCP_OAUTH_CLIENT_ID/SECRET — not our
+       case, gateway-fronted).
+    2. `google.auth.default(scopes=[ADS_SCOPE])` — Application Default
+       Credentials.
+  It deliberately does NOT support `google-ads.yaml` or env-var fallback
+  to a refresh_token directly.
 
-  - The official MCP defines ``mcp = FastMCP("Google Ads Server")`` at
-    ``ads_mcp.coordinator``, where ``FastMCP`` comes from the
-    ``fastmcp>=3.2`` package (gofastmcp.com), NOT from
-    ``mcp.server.fastmcp`` (which is the official MCP SDK's
-    bundled FastMCP and is a different class). The two have similar
-    APIs but distinct module paths and slightly different .run()
-    kwargs.
-  - With OAuth env vars (``GOOGLE_ADS_MCP_OAUTH_*``) the upstream's
-    ``run_server()`` activates streamable-http via the FastMCP OAuth
-    Proxy (designed for clients to do an OAuth dance).
-  - We are gateway-fronted with a worker shared secret; the model
-    cannot do an OAuth flow. So we deliberately leave OAUTH_* vars
-    unset and bypass ``run_server()`` entirely. We import the FastMCP
-    instance directly and call ``mcp.run(transport="streamable-http",
-    host=..., port=..., path=...)`` with explicit kwargs — fastmcp 3.x
-    defaults the path to ``"/mcp/"`` and the port to 8000, so we must
-    override both for the gateway to reach us at the expected URL.
-  - Auth uses google-ads.yaml (static creds: developer_token, client_id,
-    client_secret, refresh_token, login_customer_id). We materialize
-    the yaml from env vars on container start and point the
-    google-ads-python lib at it via
-    ``GOOGLE_ADS_CONFIGURATION_FILE_PATH``.
+  Workaround: ADC supports a "authorized_user" credential type, which is
+  exactly the shape `gcloud auth application-default login` produces — a
+  JSON file holding {client_id, client_secret, refresh_token,
+  type: "authorized_user"}. We construct that file from our existing
+  .env values and point GOOGLE_APPLICATION_CREDENTIALS at it. The
+  google-auth library then mints access tokens from the refresh token
+  on demand. Same scope (https://www.googleapis.com/auth/adwords) the
+  refresh token was originally issued for, so no re-minting needed.
 
-This sidesteps the original tunnel-zombie problem by removing the
-supergateway --stateless respawn-storm entirely (single in-process
-FastMCP, persistent gRPC channels).
+Other env (read directly by ads_mcp/utils.py):
+  - GOOGLE_ADS_DEVELOPER_TOKEN (required)
+  - GOOGLE_ADS_LOGIN_CUSTOMER_ID (optional; we set it to the MCC)
+
+Transport:
+  - The upstream uses the standalone `fastmcp` package (gofastmcp.com,
+    >=3.x), NOT `mcp.server.fastmcp.FastMCP` from the official MCP SDK.
+    Different defaults, different override surface — see
+    feedback_two_fastmcp_packages.md.
+  - We bypass run_server() (which would pick stdio without OAuth env)
+    and call mcp.run() with explicit host/port/path kwargs.
 """
 from __future__ import annotations
 
+import json
 import os
-import sys
 
 
-def _materialize_google_ads_yaml() -> None:
-    """Build /tmp/google-ads.yaml from env vars and point the SDK at it.
+def _materialize_adc_credentials() -> None:
+    """Build a `gcloud auth application-default login`-style JSON file.
 
-    The google-ads-python client reads its config from a yaml file at
-    ``GOOGLE_ADS_CONFIGURATION_FILE_PATH`` (or ~/google-ads.yaml by default).
-    We accept the same env vars the previous .env already has so no
-    credential rotation is needed for the cutover.
+    google.auth.default() reads the path in GOOGLE_APPLICATION_CREDENTIALS,
+    detects type="authorized_user", and constructs Credentials that
+    auto-refresh from the embedded refresh_token. The MCP code then sees
+    valid ADC and skips the "default credentials not found" error path.
     """
     required = {
-        "GOOGLE_ADS_DEVELOPER_TOKEN": "developer_token",
         "GOOGLE_ADS_OAUTH_CLIENT_ID": "client_id",
         "GOOGLE_ADS_OAUTH_CLIENT_SECRET": "client_secret",
         "GOOGLE_ADS_OAUTH_REFRESH_TOKEN": "refresh_token",
-        "GOOGLE_ADS_LOGIN_CUSTOMER_ID": "login_customer_id",
     }
     missing = [k for k in required if not os.environ.get(k)]
     if missing:
         raise RuntimeError(
-            f"Missing required env vars for google-ads.yaml: {missing}"
+            f"Missing OAuth env vars for ADC authorized_user JSON: {missing}"
         )
 
-    yaml_path = "/tmp/google-ads.yaml"
-    with open(yaml_path, "w", encoding="utf-8") as f:
-        for env_name, yaml_key in required.items():
-            value = os.environ[env_name]
-            # Quote with single quotes; refresh tokens have / and = which yaml
-            # reads fine but quoting removes any ambiguity.
-            f.write(f"{yaml_key}: '{value}'\n")
-        f.write("use_proto_plus: True\n")
-    os.chmod(yaml_path, 0o600)
-    os.environ["GOOGLE_ADS_CONFIGURATION_FILE_PATH"] = yaml_path
+    adc = {yaml_key: os.environ[env_name] for env_name, yaml_key in required.items()}
+    adc["type"] = "authorized_user"
+
+    adc_path = "/tmp/google-ads-adc.json"
+    with open(adc_path, "w", encoding="utf-8") as f:
+        json.dump(adc, f)
+    os.chmod(adc_path, 0o600)
+    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = adc_path
+
+    # Sanity-check the developer token is set (read directly by the MCP).
+    if not os.environ.get("GOOGLE_ADS_DEVELOPER_TOKEN"):
+        raise RuntimeError("GOOGLE_ADS_DEVELOPER_TOKEN is required.")
 
 
 def main() -> None:
-    _materialize_google_ads_yaml()
+    _materialize_adc_credentials()
 
     # Importing ads_mcp.server triggers ``from ads_mcp.tools import ...`` and
     # ``from ads_mcp.resources import ...``, which register all handlers on


### PR DESCRIPTION
Hotfix on top of #16. PR #15+#16 deployed but every tool call failed with `Your default credentials were not found`. Root cause: the official MCP's `_create_credentials()` only supports FastMCP-injected tokens or `google.auth.default()` (ADC) — it deliberately ignores google-ads.yaml and refresh_token env vars.

Fix: build a `gcloud auth application-default login`-style "authorized_user" JSON from existing .env values (`{client_id, client_secret, refresh_token, type: "authorized_user"}`), point `GOOGLE_APPLICATION_CREDENTIALS` at it. google-auth auto-refreshes access tokens from the embedded refresh_token. Same scope the original token was minted for. Zero credential rotation.

Will merge as soon as CI is green.