### PR TITLE
feat(auth): allow @choiz.com.ar and @gotimeless.ai in addition to @choiz.com.mx

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -19,6 +19,11 @@ services:
     environment:
       PORT: "8080"
       WORKER_SHARED_SECRET: ${WORKER_SHARED_SECRET:?set WORKER_SHARED_SECRET in .env}
+      # Comma-separated list of Workspace domains the gateway will accept on
+      # the X-Choiz-User-Email header. Mirrors the Worker's
+      # ALLOWED_EMAIL_DOMAINS. Defaults inside auth.ts cover the same three
+      # if the env is unset, so this is mainly for explicitness + override.
+      ALLOWED_EMAIL_DOMAINS: ${ALLOWED_EMAIL_DOMAINS:-choiz.com.mx,choiz.com.ar,gotimeless.ai}
       UPSTREAM_WAREHOUSE: "http://warehouse_mcp:8080"
       UPSTREAM_META_ADS: "http://meta_ads_mcp:8080"
       UPSTREAM_FACEBOOK_CHOIZ: "http://facebook_choiz_mcp:8080"

--- a/gateway/src/auth.ts
+++ b/gateway/src/auth.ts
@@ -5,6 +5,18 @@ if (!SHARED_SECRET) {
   throw new Error("WORKER_SHARED_SECRET env var is required");
 }
 
+// Comma-separated list of Google Workspace domains we accept. Mirrors the
+// Worker-side ALLOWED_EMAIL_DOMAINS — defense-in-depth: the Worker is
+// already enforcing this after Google OAuth, but the gateway re-checks in
+// case someone bypasses the Worker by leaking the shared secret. Defaults
+// keep the gateway functional even if the env var is missing.
+const ALLOWED_DOMAINS = (
+  process.env.ALLOWED_EMAIL_DOMAINS ?? "choiz.com.mx,choiz.com.ar,gotimeless.ai"
+)
+  .split(",")
+  .map((d) => d.trim())
+  .filter(Boolean);
+
 export interface AuthenticatedUser {
   email: string;
 }
@@ -16,7 +28,8 @@ export interface AuthenticatedUser {
  *
  * The authenticated email comes from the Worker after it completes the
  * Google Workspace OAuth flow, so we can trust it IFF the shared secret
- * matches.
+ * matches. We still re-validate the email's domain against the allowlist
+ * so a leaked shared secret cannot be used to inject arbitrary identities.
  */
 export function authenticate(req: Request): AuthenticatedUser | null {
   const secret = req.header("x-worker-shared-secret");
@@ -24,7 +37,8 @@ export function authenticate(req: Request): AuthenticatedUser | null {
 
   const email = req.header("x-choiz-user-email");
   if (!email) return null;
-  if (!email.endsWith("@choiz.com.mx")) return null;
+  const domain = email.split("@")[1] ?? "";
+  if (!ALLOWED_DOMAINS.includes(domain)) return null;
 
   return { email };
 }

--- a/worker/src/api-handler.ts
+++ b/worker/src/api-handler.ts
@@ -12,8 +12,9 @@ import type { UserProps, WorkerEnv } from "./types.js";
  *   4. If invalid/expired, returns 401 before we ever run.
  *
  * So by the time this function is called, the caller has PROVEN they are a
- * specific @choiz.com.mx user (because Google signed off) and we can safely
- * stamp that identity into the upstream request.
+ * specific user in one of the ALLOWED_EMAIL_DOMAINS Workspaces (because
+ * Google signed off) and we can safely stamp that identity into the upstream
+ * request.
  *
  * Transport: the upstream pipeline (gateway -> adapter -> MCP server) speaks
  * MCP Streamable HTTP end-to-end, which is what claude.ai uses. The adapter

--- a/worker/src/default-handler.ts
+++ b/worker/src/default-handler.ts
@@ -13,7 +13,8 @@ import type { UserProps, WorkerEnv } from "./types.js";
  *   Google -> GET /callback?code=...&state=...
  *     -> we exchange the code for Google's access_token
  *     -> we fetch the user's email from Google
- *     -> we verify the email is @choiz.com.mx and email_verified=true
+ *     -> we verify email_verified=true and the email's domain is in
+ *        ALLOWED_EMAIL_DOMAINS (comma-separated list of Workspace domains)
  *     -> we call completeAuthorization(...) with the user's email as props
  *         -> this mints an opaque token, stores it in OAUTH_KV, and gives us
  *            a redirect URL back to the original claude.ai redirect_uri
@@ -45,8 +46,12 @@ app.get("/authorize", async (c) => {
   googleUrl.searchParams.set("response_type", "code");
   googleUrl.searchParams.set("scope", "openid email profile");
   googleUrl.searchParams.set("state", state);
-  // `hd` hints the Workspace domain so the Google account picker pre-filters.
-  googleUrl.searchParams.set("hd", c.env.ALLOWED_EMAIL_DOMAIN);
+  // `hd=*` hints the Google account picker to show ANY Workspace account
+  // (rather than a single domain). We accept multiple domains
+  // (ALLOWED_EMAIL_DOMAINS), so a single-domain hd hint would hide accounts
+  // from the other allowed Workspaces. The post-callback check below still
+  // enforces the actual domain allowlist.
+  googleUrl.searchParams.set("hd", "*");
   // Force consent the first time, then skip it on subsequent logins.
   googleUrl.searchParams.set("prompt", "select_account");
 
@@ -109,9 +114,19 @@ app.get("/callback", async (c) => {
   if (!user.email || !user.email_verified) {
     return c.text("Google account has no verified email", 403);
   }
-  const domain = c.env.ALLOWED_EMAIL_DOMAIN;
-  if (!user.email.endsWith(`@${domain}`)) {
-    return c.text(`Only @${domain} accounts are allowed. You signed in as ${user.email}.`, 403);
+  const allowedDomains = c.env.ALLOWED_EMAIL_DOMAINS
+    .split(",")
+    .map((d) => d.trim())
+    .filter(Boolean);
+  const userDomain = user.email.split("@")[1] ?? "";
+  if (!allowedDomains.includes(userDomain)) {
+    return c.text(
+      `Your account (${user.email}) is not in the allowed domain list. ` +
+        `Contact ops if your domain should be added. Allowed: ${allowedDomains
+          .map((d) => `@${d}`)
+          .join(", ")}.`,
+      403,
+    );
   }
 
   const props: UserProps = { email: user.email, name: user.name };

--- a/worker/worker-configuration.d.ts
+++ b/worker/worker-configuration.d.ts
@@ -8,7 +8,7 @@ declare namespace Cloudflare {
 	interface Env {
 		OAUTH_KV: KVNamespace;
 		UPSTREAM_BASE: "https://tunnel.choiz.com.mx";
-		ALLOWED_EMAIL_DOMAIN: "choiz.com.mx";
+		ALLOWED_EMAIL_DOMAINS: "choiz.com.mx,choiz.com.ar,gotimeless.ai";
 	}
 }
 interface Env extends Cloudflare.Env {}
@@ -16,7 +16,7 @@ type StringifyValues<EnvType extends Record<string, unknown>> = {
 	[Binding in keyof EnvType]: EnvType[Binding] extends string ? EnvType[Binding] : string;
 };
 declare namespace NodeJS {
-	interface ProcessEnv extends StringifyValues<Pick<Cloudflare.Env, "UPSTREAM_BASE" | "ALLOWED_EMAIL_DOMAIN">> {}
+	interface ProcessEnv extends StringifyValues<Pick<Cloudflare.Env, "UPSTREAM_BASE" | "ALLOWED_EMAIL_DOMAINS">> {}
 }
 
 // Begin runtime types

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -16,7 +16,11 @@
   ],
   "vars": {
     "UPSTREAM_BASE": "https://tunnel.choiz.com.mx",
-    "ALLOWED_EMAIL_DOMAIN": "choiz.com.mx"
+    // Comma-separated list of Workspace domains we accept. The Worker rejects
+    // any other domain after the Google callback; the Google picker is broadened
+    // via `hd=*` so users can sign in from any of these without us hardcoding
+    // a single workspace.
+    "ALLOWED_EMAIL_DOMAINS": "choiz.com.mx,choiz.com.ar,gotimeless.ai"
   },
   "kv_namespaces": [
     {


### PR DESCRIPTION
## Summary

Expands the OAuth allowlist so users with \`@choiz.com.ar\` and \`@gotimeless.ai\` Workspace accounts can authenticate, in addition to the existing \`@choiz.com.mx\`.

## Changes

### Worker (Cloudflare)

- \`worker/wrangler.jsonc\`: rename \`ALLOWED_EMAIL_DOMAIN\` → \`ALLOWED_EMAIL_DOMAINS\` (plural), comma-separated list \`\"choiz.com.mx,choiz.com.ar,gotimeless.ai\"\`.
- \`worker/src/default-handler.ts\`:
  - Replace single-domain \`endsWith()\` check with allowlist membership on the email's domain part.
  - Change Google \`hd\` hint from a specific domain to \`*\` so the picker surfaces accounts from any Workspace (otherwise it would only show one of the three). Post-callback domain check still enforces the allowlist.
  - Updated error message lists all allowed domains.
- \`worker/src/api-handler.ts\`: docstring tweak.
- \`worker/worker-configuration.d.ts\`: env type regenerated for the renamed binding.

### Gateway (EC2)

- \`gateway/src/auth.ts\`: read \`ALLOWED_EMAIL_DOMAINS\` env, parse comma list, default to the same three domains. Domain check uses \`split('@')[1]\` + array \`includes\` instead of \`endsWith\` (closes the \`@notchoiz.com.mx\` corner case).
- \`compose.yml\`: forward \`ALLOWED_EMAIL_DOMAINS\` to the gateway service.

## Deploys triggered

Both \`deploy-worker.yml\` (worker/** changed) and \`deploy-gateway.yml\` (compose.yml + gateway/** changed) will fire.

## Test plan

- [ ] Worker deploy lands; wrangler picks up the renamed var without error.
- [ ] Gateway deploy lands; smoke from claude.ai with an existing @choiz.com.mx connector still works.
- [ ] User with @choiz.com.ar account can complete the connector OAuth flow.
- [ ] User with @gotimeless.ai account can complete the connector OAuth flow.
- [ ] User with a non-allowed domain still gets rejected (negative test, ideally before merge if possible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)