### PR TITLE
feat(shopify): add multi-tenant Shopify Admin MCP (read-only)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,3 +96,21 @@ KAPSO_API_KEY=
 # choiz/timeless tenant separation is purely a route-slug convention
 # (/mcp/gsc-choiz vs /mcp/gsc-timeless); claude.ai picks the right
 # `siteUrl` per-tool-call based on the connector slug.
+
+# --- Shopify MCP (multi-tenant: choiz + timeless) ---
+#
+# Per-tenant: myshopify.com domain + Admin API access token. Each
+# token must be issued from a custom app inside its own store with at
+# minimum: read_products, read_orders, read_customers, read_inventory,
+# read_product_listings, read_locations, read_price_rules,
+# read_metafields. Missing scopes surface as opaque 403s from the
+# GraphQL endpoint.
+#
+# The container wraps GeLi2001/shopify-mcp and exposes only the
+# read-only subset of tools (filtered in mcp/shopify/entrypoint.mjs by
+# the "get-" name prefix). Writes are not reachable from claude.ai
+# even if a token were over-scoped.
+SHOPIFY_CHOIZ_DOMAIN=choiz-2.myshopify.com
+SHOPIFY_CHOIZ_ACCESS_TOKEN=
+SHOPIFY_TIMELESS_DOMAIN=gotimeless-ai.myshopify.com
+SHOPIFY_TIMELESS_ACCESS_TOKEN=

--- a/.github/workflows/deploy-gateway.yml
+++ b/.github/workflows/deploy-gateway.yml
@@ -51,6 +51,7 @@ jobs:
       google_ads: ${{ steps.filter.outputs.google_ads }}
       ga4: ${{ steps.filter.outputs.ga4 }}
       gsc: ${{ steps.filter.outputs.gsc }}
+      shopify: ${{ steps.filter.outputs.shopify }}
       compose: ${{ steps.filter.outputs.compose }}
     steps:
       - uses: actions/checkout@v4
@@ -74,6 +75,8 @@ jobs:
               - 'mcp/ga4/**'
             gsc:
               - 'mcp/gsc/**'
+            shopify:
+              - 'mcp/shopify/**'
             compose:
               - 'compose.yml'
 
@@ -295,13 +298,40 @@ jobs:
           cache-from: type=gha,scope=gsc
           cache-to: type=gha,mode=max,scope=gsc
 
+  build-shopify:
+    name: Build shopify image
+    needs: changes
+    if: needs.changes.outputs.shopify == 'true' || needs.changes.outputs.compose == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./mcp/shopify
+          push: true
+          platforms: linux/arm64
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/shopify:latest
+            ${{ env.IMAGE_PREFIX }}/shopify:${{ github.sha }}
+          cache-from: type=gha,scope=shopify
+          cache-to: type=gha,mode=max,scope=shopify
+
   deploy:
     name: Deploy on EC2 via SSM
-    needs: [build-gateway, build-warehouse, build-meta-ads, build-facebook, build-instagram, build-google-ads, build-ga4, build-gsc]
+    needs: [build-gateway, build-warehouse, build-meta-ads, build-facebook, build-instagram, build-google-ads, build-ga4, build-gsc, build-shopify]
     # Run only if at least one build succeeded. If all builds were skipped
     # (because nothing relevant changed, e.g. workflow-only edit), do not
     # touch the EC2 — there's nothing to deploy.
-    if: ${{ !cancelled() && !failure() && (needs.build-gateway.result == 'success' || needs.build-warehouse.result == 'success' || needs.build-meta-ads.result == 'success' || needs.build-facebook.result == 'success' || needs.build-instagram.result == 'success' || needs.build-google-ads.result == 'success' || needs.build-ga4.result == 'success' || needs.build-gsc.result == 'success') }}
+    if: ${{ !cancelled() && !failure() && (needs.build-gateway.result == 'success' || needs.build-warehouse.result == 'success' || needs.build-meta-ads.result == 'success' || needs.build-facebook.result == 'success' || needs.build-instagram.result == 'success' || needs.build-google-ads.result == 'success' || needs.build-ga4.result == 'success' || needs.build-gsc.result == 'success' || needs.build-shopify.result == 'success') }}
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -38,3 +38,11 @@ services:
   gsc_timeless_mcp:
     build: ./mcp/gsc
     image: ghcr.io/choizapp/choiz-mcp-gateway/gsc:dev
+
+  shopify_choiz_mcp:
+    build: ./mcp/shopify
+    image: ghcr.io/choizapp/choiz-mcp-gateway/shopify:dev
+
+  shopify_timeless_mcp:
+    build: ./mcp/shopify
+    image: ghcr.io/choizapp/choiz-mcp-gateway/shopify:dev

--- a/compose.yml
+++ b/compose.yml
@@ -34,6 +34,8 @@ services:
       UPSTREAM_GA4_TIMELESS: "http://ga4_timeless_mcp:8080"
       UPSTREAM_GSC_CHOIZ: "http://gsc_choiz_mcp:8080"
       UPSTREAM_GSC_TIMELESS: "http://gsc_timeless_mcp:8080"
+      UPSTREAM_SHOPIFY_CHOIZ: "http://shopify_choiz_mcp:8080"
+      UPSTREAM_SHOPIFY_TIMELESS: "http://shopify_timeless_mcp:8080"
       # Remote MCPs proxied through the gateway (no internal container).
       # The route is only registered if the corresponding API key is set;
       # gateway/src/index.ts logs a skip-warning otherwise. See memory
@@ -60,6 +62,8 @@ services:
       - ga4_timeless_mcp
       - gsc_choiz_mcp
       - gsc_timeless_mcp
+      - shopify_choiz_mcp
+      - shopify_timeless_mcp
       - google_ads_mcp
     restart: unless-stopped
 
@@ -219,4 +223,41 @@ services:
       GOOGLE_ADS_OAUTH_REFRESH_TOKEN: ${GOOGLE_ADS_OAUTH_REFRESH_TOKEN:?set GOOGLE_ADS_OAUTH_REFRESH_TOKEN in .env}
       GOOGLE_ADS_DEVELOPER_TOKEN: ${GOOGLE_ADS_DEVELOPER_TOKEN:?set GOOGLE_ADS_DEVELOPER_TOKEN in .env}
       GOOGLE_ADS_LOGIN_CUSTOMER_ID: ${GOOGLE_ADS_LOGIN_CUSTOMER_ID:?set GOOGLE_ADS_LOGIN_CUSTOMER_ID in .env}
+    restart: unless-stopped
+
+  # Shopify MCP — multi-tenant pattern (one image, two services), mirrors
+  # facebook / instagram. Wraps GeLi2001/shopify-mcp's tools/registry but
+  # exposes a READ-ONLY subset (names matching get-*); writes
+  # (create-/update-/delete-/order-cancel/refund-create/inventory-set/...)
+  # are filtered out in mcp/shopify/entrypoint.mjs.
+  #
+  # Architecture: same in-process Node pattern as gsc. No supergateway,
+  # no per-request child churn. McpServer is mounted behind
+  # StreamableHTTPServerTransport on :8080.
+  #
+  # Per-tenant differences: MYSHOPIFY_DOMAIN + SHOPIFY_ACCESS_TOKEN.
+  # The Admin tokens must carry at minimum: read_products, read_orders,
+  # read_customers, read_inventory, read_product_listings,
+  # read_locations, read_price_rules, read_metafields. Missing scopes
+  # surface as opaque 403s from the GraphQL endpoint.
+  #
+  # Payload ceiling caveat: claude.ai rejects MCP tool results above
+  # ~2-3 KB. Shopify `get-orders`/`get-products` responses with full
+  # line items + variants will overshoot — pass `limit` low (≤5) on
+  # list calls. The entrypoint already serializes with compact
+  # JSON.stringify (no indent). If we hit the ceiling in real use, the
+  # next iteration is a field-trimming wrapper similar to the
+  # google-ads MessageToDict filter (see project_mcp_patterns_learned).
+  shopify_choiz_mcp:
+    image: ghcr.io/choizapp/choiz-mcp-gateway/shopify:${IMAGE_TAG:-latest}
+    environment:
+      MYSHOPIFY_DOMAIN: ${SHOPIFY_CHOIZ_DOMAIN:?set SHOPIFY_CHOIZ_DOMAIN in .env}
+      SHOPIFY_ACCESS_TOKEN: ${SHOPIFY_CHOIZ_ACCESS_TOKEN:?set SHOPIFY_CHOIZ_ACCESS_TOKEN in .env}
+    restart: unless-stopped
+
+  shopify_timeless_mcp:
+    image: ghcr.io/choizapp/choiz-mcp-gateway/shopify:${IMAGE_TAG:-latest}
+    environment:
+      MYSHOPIFY_DOMAIN: ${SHOPIFY_TIMELESS_DOMAIN:?set SHOPIFY_TIMELESS_DOMAIN in .env}
+      SHOPIFY_ACCESS_TOKEN: ${SHOPIFY_TIMELESS_ACCESS_TOKEN:?set SHOPIFY_TIMELESS_ACCESS_TOKEN in .env}
     restart: unless-stopped

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -17,6 +17,8 @@ const upstreams: Record<string, string | undefined> = {
   "/mcp/ga4-timeless":       process.env.UPSTREAM_GA4_TIMELESS,
   "/mcp/gsc-choiz":          process.env.UPSTREAM_GSC_CHOIZ,
   "/mcp/gsc-timeless":       process.env.UPSTREAM_GSC_TIMELESS,
+  "/mcp/shopify-choiz":      process.env.UPSTREAM_SHOPIFY_CHOIZ,
+  "/mcp/shopify-timeless":   process.env.UPSTREAM_SHOPIFY_TIMELESS,
   // google-ads re-enabled 2026-05-07 with official googleads/google-ads-mcp
   // (PR #15). The original 2026-04-28 disable was due to supergateway
   // --stateless gRPC respawn-storms; the official MCP runs in-process under

--- a/mcp/shopify/Dockerfile
+++ b/mcp/shopify/Dockerfile
@@ -1,0 +1,51 @@
+# Shopify MCP — Admin GraphQL API (products, orders, customers,
+# inventory, collections, metafields, ...).
+#
+# Source: https://github.com/GeLi2001/shopify-mcp — public package, no
+# Choiz fork. Cloned at build time at a pinned commit. We need the
+# package's compiled `dist/tools/registry.js` (the `tools` array of
+# initialize/execute objects) so our entrypoint can register a curated
+# read-only subset on its own McpServer behind StreamableHTTPServerTransport.
+#
+# The upstream `dist/index.js` is a stdio-bound launcher that registers
+# ALL 31 tools (including writes: create/update/delete/cancel/refund/
+# inventory-set/...). We bypass it entirely; see entrypoint.mjs for the
+# allowlist policy. Architectural shape is identical to mcp/gsc — single
+# in-process Node server, no supergateway, no per-request child churn.
+#
+# Multi-tenant pattern (same as facebook / instagram / ga4 / gsc):
+# TWO services in compose.yml, one image. Per-tenant differences:
+#   MYSHOPIFY_DOMAIN  — choiz-2.myshopify.com vs gotimeless-ai.myshopify.com
+#   SHOPIFY_ACCESS_TOKEN — admin API access token per store
+# The slug `/mcp/shopify-<tenant>/` is the only thing claude.ai sees.
+
+FROM node:20-slim
+
+ARG SHOPIFY_MCP_SHA=c90faaf434023bd22c1beb6bd59ff735bca18fac
+
+# git: clone source at build time. ca-certificates: HTTPS to
+# <shop>.myshopify.com/admin/api/.../graphql.json.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Clone + build. `npm install` (without --production) fetches devDeps
+# required by tsc; `npm run build` compiles to dist/. Pruning afterwards
+# trims devDeps so the runtime image stays small.
+RUN git clone https://github.com/GeLi2001/shopify-mcp.git . \
+ && git checkout "${SHOPIFY_MCP_SHA}" \
+ && npm install \
+ && npm run build \
+ && npm prune --production
+
+# Our streamable-http launcher. Lives in /app so its
+# `import "./dist/tools/registry.js"` and
+# `import "@modelcontextprotocol/sdk/..."` both resolve against
+# /app/node_modules.
+COPY entrypoint.mjs /app/entrypoint.mjs
+
+EXPOSE 8080
+
+ENTRYPOINT ["node", "/app/entrypoint.mjs"]

--- a/mcp/shopify/entrypoint.mjs
+++ b/mcp/shopify/entrypoint.mjs
@@ -1,0 +1,139 @@
+// Shopify MCP entrypoint — serves a READ-ONLY subset of GeLi2001/shopify-mcp
+// via streamable-http, without supergateway.
+//
+// Why we don't reuse the package's launcher (dist/index.js):
+//   1. It binds StdioServerTransport, not StreamableHTTPServerTransport.
+//   2. It registers ALL tools, including writes (create-/update-/delete-/
+//      cancel-/refund-/inventory-set-...). The user asked for read-only.
+//
+// Approach: import the package's `tools` registry (each entry exposes
+// .name, .schema, .initialize(client), .execute(args)), build our own
+// GraphQLClient with X-Shopify-Access-Token, filter the tools array to
+// names starting with "get-" (read convention used uniformly across the
+// package's 20 read tools), then register them on an McpServer mounted
+// behind StreamableHTTPServerTransport.
+//
+// The `get-` prefix rule is intentional and structural:
+//   * Every read tool in src/tools/registry.ts is named get-* (per the
+//     package's getProducts, getOrders, getCustomers, getShopInfo, ...
+//     convention as of SHA c90faaf4).
+//   * Every write tool starts with create-/update-/delete-/order-/
+//     customer-/refund-/set-/manage-/inventory-set-/complete-.
+//   * If the upstream adds a non-get- read tool we miss it; if they add
+//     a write tool prefixed get- we wrongly include it. Both are
+//     unlikely given the consistency of the existing naming. The
+//     container logs the final allowed list on boot so drift is easy
+//     to spot in `docker compose logs`.
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { GraphQLClient } from "graphql-request";
+import { randomUUID } from "node:crypto";
+import http from "node:http";
+
+import { tools } from "./dist/tools/registry.js";
+
+function readEnv() {
+  const domain = process.env.MYSHOPIFY_DOMAIN;
+  const token = process.env.SHOPIFY_ACCESS_TOKEN;
+  const apiVersion = process.env.SHOPIFY_API_VERSION || "2026-01";
+
+  if (!domain) throw new Error("MYSHOPIFY_DOMAIN env var is required");
+  if (!token) throw new Error("SHOPIFY_ACCESS_TOKEN env var is required");
+
+  // The upstream package reads MYSHOPIFY_DOMAIN from process.env at
+  // various points (e.g. for error messages). Mirror what its
+  // dist/index.js does for parity.
+  process.env.MYSHOPIFY_DOMAIN = domain;
+  process.env.SHOPIFY_ACCESS_TOKEN = token;
+
+  return { domain, token, apiVersion };
+}
+
+async function main() {
+  const { domain, token, apiVersion } = readEnv();
+
+  const shopifyClient = new GraphQLClient(
+    `https://${domain}/admin/api/${apiVersion}/graphql.json`,
+    {
+      headers: {
+        "X-Shopify-Access-Token": token,
+        "Content-Type": "application/json",
+      },
+    },
+  );
+
+  // Filter the upstream registry to read-only tools. See file header
+  // for the rationale behind the get-* convention.
+  const readOnly = tools.filter((t) => t.name.startsWith("get-"));
+  const denied = tools.filter((t) => !t.name.startsWith("get-")).map((t) => t.name);
+
+  // Initialize only the tools we'll actually expose. Each tool's
+  // .initialize(client) stores the GraphQL client on a module-level
+  // singleton inside the tool file — same pattern the upstream uses.
+  for (const tool of readOnly) {
+    tool.initialize(shopifyClient);
+  }
+
+  const server = new McpServer({
+    name: "shopify",
+    version: "1.0.0",
+    description:
+      "Shopify Admin GraphQL — read-only subset (products, orders, customers, inventory, collections, metafields). Pass `limit` low (≤5) on list calls to stay under claude.ai's ~2-3 KB tool-result ceiling.",
+  });
+
+  for (const tool of readOnly) {
+    server.tool(tool.name, tool.schema.shape, async (args) => {
+      const result = await tool.execute(args);
+      return {
+        // Compact JSON: claude.ai rejects tool-results over ~2-3 KB.
+        // Pretty-printing alone can push a 5-product response past it.
+        content: [{ type: "text", text: JSON.stringify(result) }],
+      };
+    });
+  }
+
+  console.error(
+    `Shopify MCP: domain=${domain} apiVersion=${apiVersion} ` +
+      `allowed=${readOnly.length} denied=${denied.length}`,
+  );
+  console.error("allowed tools:", readOnly.map((t) => t.name).join(", "));
+  console.error("denied (writes):", denied.join(", "));
+
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: () => randomUUID(),
+  });
+
+  await server.connect(transport);
+
+  const httpServer = http.createServer(async (req, res) => {
+    try {
+      await transport.handleRequest(req, res);
+    } catch (err) {
+      console.error("handleRequest error:", err);
+      if (!res.headersSent) {
+        res.statusCode = 500;
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify({ error: String(err) }));
+      } else {
+        res.end();
+      }
+    }
+  });
+
+  httpServer.listen(8080, "0.0.0.0", () => {
+    console.error("Shopify MCP listening on http://0.0.0.0:8080/");
+  });
+
+  for (const sig of ["SIGINT", "SIGTERM"]) {
+    process.on(sig, () => {
+      console.error(`Received ${sig}, shutting down`);
+      httpServer.close(() => process.exit(0));
+    });
+  }
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds a Shopify Admin GraphQL MCP for both tenants: `/mcp/shopify-choiz/` (`choiz-2.myshopify.com`) and `/mcp/shopify-timeless/` (`gotimeless-ai.myshopify.com`).
- Wraps [`GeLi2001/shopify-mcp@c90faaf4`](https://github.com/GeLi2001/shopify-mcp) in a Node single-process `StreamableHTTPServerTransport` — same shape as `gsc` and `instagram`. No supergateway.
- **Read-only by policy.** `mcp/shopify/entrypoint.mjs` imports the upstream `tools/registry`, filters to names matching `get-*` (20 of 31 tools), and registers only those on its own `McpServer`. Writes (`create-`/`update-`/`delete-`/`order-cancel`/`refund-create`/`inventory-set`/`manage-`/...) are unreachable from claude.ai even if a token were over-scoped.

## What's allowed (read tools)

Products, orders, customers, customer-orders, inventory levels & items, price lists, locations, markets, collections, metafields, metafield-definitions, shop-info, order-transactions, fulfillment-orders, refund-details, product-variants-detailed. The full list is logged on container boot.

## What's denied (writes)

`create-product`, `update-product`, `delete-product`, `manage-product-variants`, `manage-product-options`, `delete-product-variants`, `create-customer`, `update-customer`, `delete-customer`, `customer-merge`, `manage-customer-address`, `update-order`, `order-cancel`, `order-close-open`, `order-mark-as-paid`, `create-fulfillment`, `create-draft-order`, `complete-draft-order`, `refund-create`, `set-metafields`, `delete-metafields`, `manage-tags`, `inventory-set-quantities`.

## Capacity check

EC2 is `t4g.medium` (4 GB RAM + 4 GB swap). Idle ~1.3 GB, current peak 2.7 GB. Two Node single-process wrappers (~60–100 MB each) add ~150–250 MB. New projected peak ~2.95 GB, ~1 GB headroom over physical RAM. No upsizing required.

## Required env (already set on EC2 .env per offline confirmation)

```
SHOPIFY_CHOIZ_DOMAIN=choiz-2.myshopify.com
SHOPIFY_CHOIZ_ACCESS_TOKEN=shpat_...
SHOPIFY_TIMELESS_DOMAIN=gotimeless-ai.myshopify.com
SHOPIFY_TIMELESS_ACCESS_TOKEN=shpat_...
```

Token scopes required (per store): `read_products`, `read_orders`, `read_customers`, `read_inventory`, `read_product_listings`, `read_locations`, `read_price_rules`, `read_metafields`. Missing scopes surface as opaque 403s from the GraphQL endpoint.

## Known caveat — payload ceiling

claude.ai rejects MCP tool results above ~2-3 KB (no server-side trace; see `project_claudeai_payload_ceiling`). `get-orders` / `get-products` with full line items + variants will overshoot. Entrypoint already uses compact `JSON.stringify` (no indent); operationally we'll need to pass `limit` low (≤5) on list calls. If it bites in real use, the next iteration is a field-trimming wrapper similar to the google-ads `MessageToDict` filter.

## Files

- New: `mcp/shopify/Dockerfile` (Node 20, clones + builds upstream at pinned SHA, then `npm prune --production`)
- New: `mcp/shopify/entrypoint.mjs` (read-only allowlist + StreamableHTTPServerTransport mount)
- Modified: `compose.yml` (2 services + gateway upstreams + depends_on)
- Modified: `compose.dev.yml` (local build entries)
- Modified: `gateway/src/index.ts` (2 routes in `upstreams` map)
- Modified: `.github/workflows/deploy-gateway.yml` (filter + `build-shopify` job + deploy `needs:`/`if:`)
- Modified: `.env.example` (4 new vars documented)

## Test plan

- [ ] CI builds the `shopify` image successfully (linux/arm64)
- [ ] Post-merge deploy: `docker compose ps` shows `shopify_choiz_mcp` + `shopify_timeless_mcp` as `Up`
- [ ] Container logs show `Shopify MCP listening on http://0.0.0.0:8080/` plus the explicit `allowed tools:` and `denied (writes):` lines
- [ ] Smoke from EC2 over SSM:
  ```
  curl -i -X POST http://localhost:8080/mcp/shopify-choiz/ \
    -H "x-worker-shared-secret: $(grep ^WORKER_SHARED_SECRET /home/ssm-user/choiz-mcp-gateway/.env | cut -d= -f2)" \
    -H "x-choiz-user-email: sabruzzini@choiz.com.mx" \
    -H "content-type: application/json" \
    -H "accept: application/json, text/event-stream" \
    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"curl","version":"0"}}}'
  ```
  → expect `HTTP/1.1 200 OK` + `"serverInfo":{"name":"shopify",...}`
- [ ] Same for `/mcp/shopify-timeless/`
- [ ] In claude.ai: add both connectors at `https://mcp.choiz.com.mx/mcp/shopify-choiz/` and `…/shopify-timeless/`; call `get-shop-info` on each → returns the respective store
- [ ] `get-products` with `limit: 3` returns under the payload ceiling

🤖 Generated with [Claude Code](https://claude.com/claude-code)