### PR TITLE
fix(shopify): per-session McpServer + transport

### DIFF
--- a/mcp/shopify/entrypoint.mjs
+++ b/mcp/shopify/entrypoint.mjs
@@ -1,32 +1,30 @@
 // Shopify MCP entrypoint — serves a READ-ONLY subset of GeLi2001/shopify-mcp
-// via streamable-http, without supergateway.
+// via streamable-http with per-session McpServer + StreamableHTTPServerTransport.
 //
 // Why we don't reuse the package's launcher (dist/index.js):
 //   1. It binds StdioServerTransport, not StreamableHTTPServerTransport.
 //   2. It registers ALL tools, including writes (create-/update-/delete-/
 //      cancel-/refund-/inventory-set-...). The user asked for read-only.
 //
-// Approach: import the package's `tools` registry (each entry exposes
-// .name, .schema, .initialize(client), .execute(args)), build our own
-// GraphQLClient with X-Shopify-Access-Token, filter the tools array to
-// names starting with "get-" (read convention used uniformly across the
-// package's 20 read tools), then register them on an McpServer mounted
-// behind StreamableHTTPServerTransport.
+// Architecture (canonical MCP TS SDK session pattern):
+//   * Module-level: one GraphQLClient (Admin GraphQL) + initialized
+//     read-only tools registry. Both are stateless w.r.t. MCP sessions
+//     and safely shared across all client sessions.
+//   * Per HTTP session: a fresh McpServer + StreamableHTTPServerTransport
+//     pair, stored in `transports` keyed by Mcp-Session-Id. Sharing a
+//     single McpServer across sessions causes "Server already initialized"
+//     on every initialize after the first — surfaces in claude.ai as a
+//     generic "Authorization failed + ofid_..." error.
 //
-// The `get-` prefix rule is intentional and structural:
-//   * Every read tool in src/tools/registry.ts is named get-* (per the
-//     package's getProducts, getOrders, getCustomers, getShopInfo, ...
-//     convention as of SHA c90faaf4).
-//   * Every write tool starts with create-/update-/delete-/order-/
-//     customer-/refund-/set-/manage-/inventory-set-/complete-.
-//   * If the upstream adds a non-get- read tool we miss it; if they add
-//     a write tool prefixed get- we wrongly include it. Both are
-//     unlikely given the consistency of the existing naming. The
-//     container logs the final allowed list on boot so drift is easy
-//     to spot in `docker compose logs`.
+// Allowlist policy: names starting with "get-" (21 read tools in the
+// upstream registry at SHA c90faaf4). Every write tool starts with
+// create-/update-/delete-/order-/customer-/refund-/set-/manage-/
+// inventory-set-/complete-. The container logs allowed + denied lists
+// on boot so drift against upstream is easy to spot.
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { GraphQLClient } from "graphql-request";
 import { randomUUID } from "node:crypto";
 import http from "node:http";
@@ -41,99 +39,179 @@ function readEnv() {
   if (!domain) throw new Error("MYSHOPIFY_DOMAIN env var is required");
   if (!token) throw new Error("SHOPIFY_ACCESS_TOKEN env var is required");
 
-  // The upstream package reads MYSHOPIFY_DOMAIN from process.env at
-  // various points (e.g. for error messages). Mirror what its
-  // dist/index.js does for parity.
   process.env.MYSHOPIFY_DOMAIN = domain;
   process.env.SHOPIFY_ACCESS_TOKEN = token;
 
   return { domain, token, apiVersion };
 }
 
-async function main() {
-  const { domain, token, apiVersion } = readEnv();
+const { domain, token, apiVersion } = readEnv();
 
-  const shopifyClient = new GraphQLClient(
-    `https://${domain}/admin/api/${apiVersion}/graphql.json`,
-    {
-      headers: {
-        "X-Shopify-Access-Token": token,
-        "Content-Type": "application/json",
-      },
+const shopifyClient = new GraphQLClient(
+  `https://${domain}/admin/api/${apiVersion}/graphql.json`,
+  {
+    headers: {
+      "X-Shopify-Access-Token": token,
+      "Content-Type": "application/json",
     },
-  );
+  },
+);
 
-  // Filter the upstream registry to read-only tools. See file header
-  // for the rationale behind the get-* convention.
-  const readOnly = tools.filter((t) => t.name.startsWith("get-"));
-  const denied = tools.filter((t) => !t.name.startsWith("get-")).map((t) => t.name);
+// Filter the upstream registry to read-only tools.
+const readOnly = tools.filter((t) => t.name.startsWith("get-"));
+const denied = tools.filter((t) => !t.name.startsWith("get-")).map((t) => t.name);
 
-  // Initialize only the tools we'll actually expose. Each tool's
-  // .initialize(client) stores the GraphQL client on a module-level
-  // singleton inside the tool file — same pattern the upstream uses.
-  for (const tool of readOnly) {
-    tool.initialize(shopifyClient);
-  }
+// Each tool's .initialize(client) stores the GraphQL client on a
+// module-level singleton inside the tool's file. Safe to call once at
+// startup — the client itself is concurrency-safe (a graphql-request
+// GraphQLClient is just an HTTP wrapper with no per-request state).
+for (const tool of readOnly) {
+  tool.initialize(shopifyClient);
+}
 
+console.error(
+  `Shopify MCP: domain=${domain} apiVersion=${apiVersion} ` +
+    `allowed=${readOnly.length} denied=${denied.length}`,
+);
+console.error("allowed tools:", readOnly.map((t) => t.name).join(", "));
+console.error("denied (writes):", denied.join(", "));
+
+// Build a fresh McpServer with the read-only tools registered. Called
+// once per new MCP session (i.e. per claude.ai connector connection).
+function buildMcpServer() {
   const server = new McpServer({
     name: "shopify",
     version: "1.0.0",
     description:
-      "Shopify Admin GraphQL — read-only subset (products, orders, customers, inventory, collections, metafields). Pass `limit` low (≤5) on list calls to stay under claude.ai's ~2-3 KB tool-result ceiling.",
+      "Shopify Admin GraphQL — read-only subset (products, orders, customers, inventory, collections, metafields). Pass `limit` low (<=5) on list calls to stay under claude.ai's ~2-3 KB tool-result ceiling.",
   });
-
   for (const tool of readOnly) {
     server.tool(tool.name, tool.schema.shape, async (args) => {
       const result = await tool.execute(args);
       return {
         // Compact JSON: claude.ai rejects tool-results over ~2-3 KB.
-        // Pretty-printing alone can push a 5-product response past it.
         content: [{ type: "text", text: JSON.stringify(result) }],
       };
     });
   }
-
-  console.error(
-    `Shopify MCP: domain=${domain} apiVersion=${apiVersion} ` +
-      `allowed=${readOnly.length} denied=${denied.length}`,
-  );
-  console.error("allowed tools:", readOnly.map((t) => t.name).join(", "));
-  console.error("denied (writes):", denied.join(", "));
-
-  const transport = new StreamableHTTPServerTransport({
-    sessionIdGenerator: () => randomUUID(),
-  });
-
-  await server.connect(transport);
-
-  const httpServer = http.createServer(async (req, res) => {
-    try {
-      await transport.handleRequest(req, res);
-    } catch (err) {
-      console.error("handleRequest error:", err);
-      if (!res.headersSent) {
-        res.statusCode = 500;
-        res.setHeader("content-type", "application/json");
-        res.end(JSON.stringify({ error: String(err) }));
-      } else {
-        res.end();
-      }
-    }
-  });
-
-  httpServer.listen(8080, "0.0.0.0", () => {
-    console.error("Shopify MCP listening on http://0.0.0.0:8080/");
-  });
-
-  for (const sig of ["SIGINT", "SIGTERM"]) {
-    process.on(sig, () => {
-      console.error(`Received ${sig}, shutting down`);
-      httpServer.close(() => process.exit(0));
-    });
-  }
+  return server;
 }
 
-main().catch((err) => {
-  console.error("Fatal:", err);
-  process.exit(1);
+// Session-id -> transport. Each transport is bound to its own
+// McpServer at creation time. Cleared via the transport's onclose
+// callback when claude.ai terminates the session (or it times out).
+const transports = Object.create(null);
+
+async function readJsonBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => {
+      if (chunks.length === 0) return resolve(undefined);
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString("utf8")));
+      } catch (err) {
+        reject(err);
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+function send400(res, message) {
+  if (res.headersSent) return;
+  res.statusCode = 400;
+  res.setHeader("content-type", "application/json");
+  res.end(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      error: { code: -32000, message },
+      id: null,
+    }),
+  );
+}
+
+async function handle(req, res) {
+  const sessionId = req.headers["mcp-session-id"];
+  const method = req.method || "GET";
+
+  if (method === "POST") {
+    let body;
+    try {
+      body = await readJsonBody(req);
+    } catch (err) {
+      send400(res, `Invalid JSON body: ${String(err)}`);
+      return;
+    }
+
+    let transport;
+    if (sessionId && transports[sessionId]) {
+      transport = transports[sessionId];
+    } else if (!sessionId && body && isInitializeRequest(body)) {
+      transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        onsessioninitialized: (id) => {
+          transports[id] = transport;
+          console.error(`session ${id} initialized`);
+        },
+      });
+      transport.onclose = () => {
+        const sid = transport.sessionId;
+        if (sid && transports[sid]) {
+          delete transports[sid];
+          console.error(`session ${sid} closed`);
+        }
+      };
+      const server = buildMcpServer();
+      await server.connect(transport);
+      await transport.handleRequest(req, res, body);
+      return;
+    } else {
+      send400(res, "Bad Request: No valid session ID provided");
+      return;
+    }
+    await transport.handleRequest(req, res, body);
+    return;
+  }
+
+  if (method === "GET" || method === "DELETE") {
+    if (!sessionId || !transports[sessionId]) {
+      send400(res, "Invalid or missing session ID");
+      return;
+    }
+    await transports[sessionId].handleRequest(req, res);
+    return;
+  }
+
+  res.statusCode = 405;
+  res.setHeader("allow", "GET, POST, DELETE");
+  res.end();
+}
+
+const httpServer = http.createServer(async (req, res) => {
+  try {
+    await handle(req, res);
+  } catch (err) {
+    console.error("handleRequest error:", err);
+    if (!res.headersSent) {
+      res.statusCode = 500;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ error: String(err) }));
+    } else {
+      try {
+        res.end();
+      } catch {}
+    }
+  }
 });
+
+httpServer.listen(8080, "0.0.0.0", () => {
+  console.error("Shopify MCP listening on http://0.0.0.0:8080/");
+});
+
+for (const sig of ["SIGINT", "SIGTERM"]) {
+  process.on(sig, () => {
+    console.error(`Received ${sig}, shutting down`);
+    httpServer.close(() => process.exit(0));
+  });
+}


### PR DESCRIPTION
## Summary

The Shopify MCP shipped in [#20](https://github.com/Choizapp/choiz-mcp-gateway/pull/20) used a single global `McpServer` + `StreamableHTTPServerTransport` for every HTTP request. The first `initialize` worked; every subsequent client's `initialize` got `HTTP 400 {"code":-32600,"message":"Invalid Request: Server already initialized"}`. claude.ai surfaces that as the generic `Authorization with the MCP server failed (ofid_...)`.

Reproduced on EC2 via SSM:

```
=== gateway initialize loop shopify-choiz (local) ===
HTTP 400
{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid Request: Server already initialized"},"id":null}
```

## Fix

Switch to the canonical MCP TS SDK session pattern (verified against [`simpleStreamableHttp.ts` on `v1.x`](https://github.com/modelcontextprotocol/typescript-sdk/blob/v1.x/src/examples/server/simpleStreamableHttp.ts)):

- **Module-level (shared, stateless w.r.t. MCP sessions):** one `GraphQLClient` + one `tools.initialize(client)` pass.
- **Per session:** a fresh `McpServer` + `StreamableHTTPServerTransport` pair, stored in a `transports` map keyed by `Mcp-Session-Id`.
- `POST` without session id + body is initialize → create new pair, attach onclose evictor, register transport via `onsessioninitialized`, then handle request.
- `POST`/`GET`/`DELETE` with session id → route to existing transport.
- Anything else → 400 with proper JSON-RPC error envelope.

`node:http` body buffering instead of pulling express. Stays small (~190 LOC) and consistent with `mcp/gsc/entrypoint.mjs` style.

## Why this didn't surface in [#20](https://github.com/Choizapp/choiz-mcp-gateway/pull/20)'s smoke test

That smoke test ran exactly **one** `initialize` against a fresh container. The bug needs N≥2 sequential initialize requests to hit. The triage SSM run today did exactly that and reproduced it.

## Possibly affected siblings

The same single-session pattern lives in [`mcp/gsc/entrypoint.mjs`](mcp/gsc/entrypoint.mjs). It hasn't surfaced because claude.ai holds the GSC connector session open; reconnects are rare. Audit + same fix tracked separately if/when it bites. Not addressing here to keep this PR scoped to the live incident.

## Test plan

- [ ] CI builds `shopify` image (linux/arm64)
- [ ] Post-merge `docker compose ps` shows `shopify_*_mcp` Up
- [ ] Container logs show `Shopify MCP listening...` plus a `session <uuid> initialized` line on first connection
- [ ] **Two sequential `initialize` curls from EC2 both return `HTTP 200`** (the previous regression)
- [ ] claude.ai connector to `https://mcp.choiz.com.mx/mcp/shopify-choiz/` connects and `get-shop-info` returns the Choiz store name
- [ ] Same for `…/shopify-timeless/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)