### PR TITLE
feat(shopify): trim heavy nested fields from LIST tool responses

### DIFF
--- a/mcp/shopify/entrypoint.mjs
+++ b/mcp/shopify/entrypoint.mjs
@@ -76,6 +76,90 @@ console.error(
 console.error("allowed tools:", readOnly.map((t) => t.name).join(", "));
 console.error("denied (writes):", denied.join(", "));
 
+// --- Response trimming -----------------------------------------------------
+//
+// claude.ai silently rejects MCP tool results above ~2-3 KB. A raw Shopify
+// Admin GraphQL response for `get-orders limit:10` is ~6-9 KB once you
+// include lineItems + shippingAddress + billingAddress + taxLines per
+// order. The model "gets stuck thinking" with no surfaced error.
+//
+// Policy: for LIST tools, drop the heavy nested fields so the response is
+// a usable summary (id, name, totals, top-level customer info, status).
+// DETAIL tools (`*-by-id`) and known-small tools (shop-info, locations,
+// markets, metafield-definitions, inventory-*, price-lists,
+// product-variants-detailed) pass through unmodified — single records
+// fit the ceiling, and detail is what the by-id calls exist for.
+//
+// Add/remove fields per tool here. The trim is recursive: any object in
+// the result tree that has a matching key gets that key deleted. This
+// covers wrappers like `{orders: [...], pageInfo: {...}}` correctly —
+// pageInfo's properties are not in TRIM_RULES so they stay.
+const TRIM_RULES = {
+  "get-orders": [
+    "lineItems",
+    "shippingAddress",
+    "billingAddress",
+    "taxLines",
+    "discountApplications",
+    "note",
+  ],
+  "get-customer-orders": [
+    "lineItems",
+    "shippingAddress",
+    "billingAddress",
+    "taxLines",
+    "discountApplications",
+    "note",
+  ],
+  "get-products": [
+    "variants",
+    "images",
+    "media",
+    "descriptionHtml",
+    "options",
+    "metafields",
+    "seo",
+  ],
+  "get-customers": ["addresses", "defaultAddress", "note", "metafields"],
+  "get-collections": ["products", "descriptionHtml", "image"],
+  "get-fulfillment-orders": ["lineItems"],
+};
+
+// Runtime telemetry: how many top-level objects had at least one field
+// stripped, per tool. Logged on every tool call. Cheap signal for
+// tuning the trim list later.
+const trimCounts = {};
+function trim(toolName, obj) {
+  const fields = TRIM_RULES[toolName];
+  if (!fields) return obj;
+  let hits = 0;
+  function walk(v) {
+    if (Array.isArray(v)) return v.map(walk);
+    if (v && typeof v === "object") {
+      const out = {};
+      let touched = false;
+      for (const [k, val] of Object.entries(v)) {
+        if (fields.includes(k)) {
+          touched = true;
+          continue;
+        }
+        out[k] = walk(val);
+      }
+      if (touched) hits++;
+      return out;
+    }
+    return v;
+  }
+  const trimmed = walk(obj);
+  if (hits > 0) {
+    trimCounts[toolName] = (trimCounts[toolName] || 0) + hits;
+    console.error(
+      `trim ${toolName}: stripped from ${hits} object(s); cumulative=${trimCounts[toolName]}`,
+    );
+  }
+  return trimmed;
+}
+
 // Build a fresh McpServer with the read-only tools registered. Called
 // once per new MCP session (i.e. per claude.ai connector connection).
 function buildMcpServer() {
@@ -83,14 +167,15 @@ function buildMcpServer() {
     name: "shopify",
     version: "1.0.0",
     description:
-      "Shopify Admin GraphQL — read-only subset (products, orders, customers, inventory, collections, metafields). Pass `limit` low (<=5) on list calls to stay under claude.ai's ~2-3 KB tool-result ceiling.",
+      "Shopify Admin GraphQL — read-only subset (products, orders, customers, inventory, collections, metafields). Lists are trimmed of heavy nested fields (lineItems, addresses, variants, images) to fit claude.ai's ~2-3 KB tool-result ceiling. For full details on a single record, use the matching `*-by-id` tool.",
   });
   for (const tool of readOnly) {
     server.tool(tool.name, tool.schema.shape, async (args) => {
-      const result = await tool.execute(args);
+      const raw = await tool.execute(args);
+      const trimmed = trim(tool.name, raw);
       return {
-        // Compact JSON: claude.ai rejects tool-results over ~2-3 KB.
-        content: [{ type: "text", text: JSON.stringify(result) }],
+        // Compact JSON: every byte counts against the ceiling.
+        content: [{ type: "text", text: JSON.stringify(trimmed) }],
       };
     });
   }


### PR DESCRIPTION
## Problem

User reported: `get-orders` with `limit:10` on shopify-timeless makes claude.ai "spin forever" with no surfaced error. `limit:2` works.

Cause: raw Shopify Admin GraphQL responses are heavy (one order ≈ 600–900 B serialized, with lineItems + shippingAddress + billingAddress + taxLines). 10 orders ≈ 6–9 KB, well over claude.ai's ~2–3 KB tool-result ceiling. Server is healthy, returns 200 OK; the bug is on claude.ai's side, silent.

## Fix

Per-tool `TRIM_RULES` map + recursive `trim()` that strips listed nested fields from every object in the result tree.

| Tool | Stripped |
|---|---|
| `get-orders` / `get-customer-orders` | `lineItems`, `shippingAddress`, `billingAddress`, `taxLines`, `discountApplications`, `note` |
| `get-products` | `variants`, `images`, `media`, `descriptionHtml`, `options`, `metafields`, `seo` |
| `get-customers` | `addresses`, `defaultAddress`, `note`, `metafields` |
| `get-collections` | `products`, `descriptionHtml`, `image` |
| `get-fulfillment-orders` | `lineItems` |

`*-by-id`, `get-shop-info`, `get-locations`, `get-markets`, `get-metafield-definitions`, `get-inventory-*`, `get-price-lists`, `get-product-variants-detailed` → **untouched** (single records fit the ceiling; detail is what those tools are for).

`McpServer.description` updated so the model knows lists are summaries and to call `*-by-id` for full detail.

## Telemetry

Each trim call logs `trim <tool>: stripped from N object(s); cumulative=M`. Lets us see what the model actually requests and tune the field list later.

## Trade-offs

- `get-products` list view loses per-variant pricing. Model must call `get-product-by-id` for variant details. One extra round-trip vs. unusable list.
- `get-orders` list view loses line-item detail. Same pattern: `get-order-by-id` for the line items of a specific order.
- If a real use case hits a stripped field we should keep, narrow `TRIM_RULES` and ship a follow-up.

## Test plan

- [ ] CI builds `shopify` image (cache hit on git clone + npm install)
- [ ] Container logs show `trim get-orders: stripped from N object(s)` after a real call
- [ ] Smoke from EC2: `get-orders limit:10` returns under ~2 KB total payload
- [ ] In claude.ai: "show me the last 10 orders from timeless" now returns data, no infinite spin

🤖 Generated with [Claude Code](https://claude.com/claude-code)