### PR TITLE
revert: shopify trim v2 (#23) — claude.ai rejects the trimmed shape

### DIFF
--- a/mcp/shopify/entrypoint.mjs
+++ b/mcp/shopify/entrypoint.mjs
@@ -95,12 +95,6 @@ console.error("denied (writes):", denied.join(", "));
 // covers wrappers like `{orders: [...], pageInfo: {...}}` correctly —
 // pageInfo's properties are not in TRIM_RULES so they stay.
 const TRIM_RULES = {
-  // get-orders v1 stripped ~10 fields per order; the remaining
-  // top-line money objects (subtotalPrice + totalShippingPrice +
-  // totalTax) plus full customer detail still leave ~500 B per order,
-  // so limit:10 = ~5 KB — above the ceiling. v2 also drops the
-  // redundant money objects (totalPrice is enough for a list view)
-  // and customer subfields the model rarely needs in a list.
   "get-orders": [
     "lineItems",
     "shippingAddress",
@@ -108,14 +102,6 @@ const TRIM_RULES = {
     "taxLines",
     "discountApplications",
     "note",
-    "subtotalPrice",
-    "totalShippingPrice",
-    "totalTax",
-    "phone",
-    "verifiedEmail",
-    "acceptsMarketing",
-    "tags",
-    "createdAt",
   ],
   "get-customer-orders": [
     "lineItems",
@@ -124,57 +110,19 @@ const TRIM_RULES = {
     "taxLines",
     "discountApplications",
     "note",
-    "subtotalPrice",
-    "totalShippingPrice",
-    "totalTax",
   ],
-  // get-products v1 still returned 7-12 KB for limit:5 because
-  // `description` (plaintext, sometimes paragraphs) and
-  // `priceRangeV2` + tags + vendor + handle + productType pile up.
-  // For a list view the model only needs id + title + status.
   "get-products": [
     "variants",
     "images",
     "media",
     "descriptionHtml",
-    "description",
     "options",
     "metafields",
     "seo",
-    "tags",
-    "vendor",
-    "productType",
-    "handle",
-    "totalInventory",
-    "priceRangeV2",
-    "compareAtPriceRange",
-    "onlineStoreUrl",
-    "tracksInventory",
-    "publishedAt",
-    "templateSuffix",
-    "giftCard",
   ],
-  "get-customers": [
-    "addresses",
-    "defaultAddress",
-    "note",
-    "metafields",
-    "phone",
-    "verifiedEmail",
-    "acceptsMarketing",
-    "amountSpent",
-    "lastOrder",
-    "tags",
-  ],
-  "get-collections": [
-    "products",
-    "descriptionHtml",
-    "description",
-    "image",
-    "seo",
-    "ruleSet",
-  ],
-  "get-fulfillment-orders": ["lineItems", "merchantRequests"],
+  "get-customers": ["addresses", "defaultAddress", "note", "metafields"],
+  "get-collections": ["products", "descriptionHtml", "image"],
+  "get-fulfillment-orders": ["lineItems"],
 };
 
 // Runtime telemetry: how many top-level objects had at least one field


### PR DESCRIPTION
## Revert reason

After deploying [#23](https://github.com/Choizapp/choiz-mcp-gateway/pull/23), claude.ai stopped returning **any** orders for shopify-timeless, even with limit:2. User reported 4 req_011Cb4... IDs in under a minute, all failing.

Server-side reproduction from EC2 (same gateway path claude.ai uses):

```
get-orders limit:2 -> HTTP 200, 1092 bytes, 2 orders fully populated
trim get-orders: stripped from 2 object(s) (logs)
```

So the server returns clean trimmed data. claude.ai is rejecting the shape downstream — most likely the strip of `createdAt` from orders (or one of the other v2-only fields) breaks claude.ai's tool-result validation or model interpretation. Pre-v2 (trim v1) was working for limit:2.

This revert restores trim v1 (PR #22) which strips heavy nested fields (lineItems, addresses, variants, descriptions) but keeps top-level scalars like `createdAt`, `subtotalPrice`, `totalTax`, etc.

After this lands, limit:10 will once again be ~6 KB and likely too big — that's the original payload-ceiling caveat. We accept that regression to restore the limit:2-3 use case. Follow-up: add fields back to TRIM_RULES one at a time with claude.ai testing between each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)