### PR TITLE
fix(shopify): return 404 on unknown Mcp-Session-Id (MCP spec compliance)

### DIFF
--- a/mcp/shopify/entrypoint.mjs
+++ b/mcp/shopify/entrypoint.mjs
@@ -203,14 +203,14 @@ async function readJsonBody(req) {
   });
 }
 
-function send400(res, message) {
+function sendError(res, status, code, message) {
   if (res.headersSent) return;
-  res.statusCode = 400;
+  res.statusCode = status;
   res.setHeader("content-type", "application/json");
   res.end(
     JSON.stringify({
       jsonrpc: "2.0",
-      error: { code: -32000, message },
+      error: { code, message },
       id: null,
     }),
   );
@@ -220,19 +220,47 @@ async function handle(req, res) {
   const sessionId = req.headers["mcp-session-id"];
   const method = req.method || "GET";
 
+  // Spec compliance (MCP 2025-03-26, Streamable HTTP transport):
+  // "If a request is sent to the server with an Mcp-Session-Id but the
+  // server has terminated the session (or the session ID was never
+  // valid), the server MUST respond with HTTP 404 Not Found."
+  //
+  // This is the recovery path after a container restart: claude.ai
+  // holds the previous container's session-id, our `transports` map is
+  // empty (the new container can't possibly know about it), so we tell
+  // the client to re-initialize. The client then sends a fresh POST
+  // without Mcp-Session-Id and an initialize body, which falls into
+  // the "new session" branch below.
+  //
+  // Pre-fix this returned 400, and claude.ai surfaced it as the
+  // generic "Authorization with the MCP server failed (ofid_...)"
+  // error with no recovery. Burned half a day chasing a non-existent
+  // payload-size ceiling before realizing every deploy was orphaning
+  // claude.ai's cached session-id.
+  if (sessionId && !transports[sessionId]) {
+    sendError(
+      res,
+      404,
+      -32001,
+      "Session not found; re-initialize with no Mcp-Session-Id",
+    );
+    return;
+  }
+
   if (method === "POST") {
     let body;
     try {
       body = await readJsonBody(req);
     } catch (err) {
-      send400(res, `Invalid JSON body: ${String(err)}`);
+      sendError(res, 400, -32700, `Invalid JSON body: ${String(err)}`);
       return;
     }
 
     let transport;
-    if (sessionId && transports[sessionId]) {
+    if (sessionId) {
+      // Known good (handled by the unknown-session check above).
       transport = transports[sessionId];
-    } else if (!sessionId && body && isInitializeRequest(body)) {
+    } else if (body && isInitializeRequest(body)) {
       transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: () => randomUUID(),
         onsessioninitialized: (id) => {
@@ -252,7 +280,7 @@ async function handle(req, res) {
       await transport.handleRequest(req, res, body);
       return;
     } else {
-      send400(res, "Bad Request: No valid session ID provided");
+      sendError(res, 400, -32000, "Bad Request: No valid session ID provided");
       return;
     }
     await transport.handleRequest(req, res, body);
@@ -260,8 +288,8 @@ async function handle(req, res) {
   }
 
   if (method === "GET" || method === "DELETE") {
-    if (!sessionId || !transports[sessionId]) {
-      send400(res, "Invalid or missing session ID");
+    if (!sessionId) {
+      sendError(res, 400, -32000, "Missing Mcp-Session-Id");
       return;
     }
     await transports[sessionId].handleRequest(req, res);


### PR DESCRIPTION
## Symptom

After every deploy that recreated the shopify container, claude.ai's connector kept sending tool calls with the **previous** container's session-id. Our server returned **HTTP 400** for those, which claude.ai surfaces as the generic "Authorization with the MCP server failed (ofid_...)" error with **no automatic recovery**. User saw "broken Shopify connector" until they manually deleted and re-added the connector.

Diagnosed today via SSM log inspection — the user's failed requests **never appeared in the container logs** as new sessions (no `session <uuid> initialized` lines), only my own smoke test from earlier. claude.ai was reusing a stale session-id from before a redeploy.

## Fix

Per MCP spec (2025-03-26, Streamable HTTP transport):

> If a request is sent to the server with an Mcp-Session-Id but the server has terminated the session (or the session ID was never valid), the server MUST respond with HTTP 404 Not Found. On 404 the client MUST start a new session by sending a fresh InitializeRequest with no session-id.

Pre-check `Mcp-Session-Id` against the `transports` map BEFORE routing by method. If present but unknown → 404 + JSON-RPC error code -32001. claude.ai then re-initializes automatically.

No urgency to merge — user is currently unblocked (manual connector recreate worked). Merging this prevents the workaround from being needed on every future deploy.

## Affects other MCPs

`mcp/gsc/entrypoint.mjs` has the same shape and likely the same latent bug; nobody hit it because the GSC connector isn't being redeployed multiple times per hour. Memory note `project_gsc_latent_session_bug.md` is the followup. Not addressed here to keep the PR scoped.

## Side note about today

The trim iteration (PRs [#22](https://github.com/Choizapp/choiz-mcp-gateway/pull/22), [#23](https://github.com/Choizapp/choiz-mcp-gateway/pull/23), [#24](https://github.com/Choizapp/choiz-mcp-gateway/pull/24)) was driven by an **unsupported folklore claim** of a "claude.ai ~2-3 KB payload ceiling" that lived in my memory. Re-investigated today: not in Anthropic docs, MCP spec, or any public source. The real cause of "spins / no response after a deploy" was always stale session-id. Trim v1 is still in place because smaller responses are still good engineering, but it was never a fix for the actual bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)