### PR TITLE
fix(powerbi): stateless_http=True to survive redeploys mid-chat

### DIFF
--- a/mcp/powerbi/entrypoint.py
+++ b/mcp/powerbi/entrypoint.py
@@ -147,11 +147,24 @@ def _execute_query(dataset_id: str, dax: str) -> list[dict[str, Any]]:
 # streamable_http_path="/" so the gateway can strip /mcp/powerbi and forward
 #   to "/". FastMCP's default is "/mcp" which would force the gateway to
 #   forward /mcp instead of /, leaking the internal path into errors.
+# stateless_http=True so every request creates an ephemeral session. This
+#   sidesteps the post-redeploy "stale Mcp-Session-Id" failure mode
+#   (feedback_stale_session_after_redeploy): the MCP Python SDK returns 400
+#   on unknown session-id when the spec says 404, and claude.ai only
+#   re-initializes on 404. With stateless=True, there is no per-session
+#   state to invalidate — every redeploy is harmless to in-flight chats.
+#   Safe for our surface: 6 stateless tool calls, no resources, no
+#   sampling, no server-to-client notifications. Differs from instagram /
+#   ga4 (which use stateless=False because their session manager is built
+#   manually around lowlevel Server — they have not hit this redeploy
+#   problem yet but are theoretically vulnerable too; revisit if it
+#   surfaces).
 mcp = FastMCP(
     name="powerbi",
     host="0.0.0.0",
     port=8080,
     streamable_http_path="/",
+    stateless_http=True,
 )
 
 


### PR DESCRIPTION
## Symptom
After PR #28 deployed, every claude.ai call to /mcp/powerbi returned an error with no body — even `list_datasets`, which doesn't touch Power BI. Container was up and healthy 50+ minutes.

## Root cause
Gateway logs showed dozens of:
\`\`\`
INFO:  172.18.0.16:42108 - \"POST / HTTP/1.1\" 400 Bad Request
INFO:  172.18.0.16:42124 - \"POST / HTTP/1.1\" 400 Bad Request
...
\`\`\`

claude.ai was still sending the **pre-redeploy `Mcp-Session-Id`** to the freshly-started container. The MCP Python SDK returns HTTP 400 on unknown session-id, but the MCP spec mandates HTTP 404 — and claude.ai only re-initializes a session when it sees 404. With 400, the client just gives up.

This is the exact failure mode tracked in `feedback_stale_session_after_redeploy` (same root cause that bit shopify post-redeploy on 2026-05-15).

## Fix
Pass `stateless_http=True` to `FastMCP(...)`. Every request now creates its own ephemeral session, so there is no per-session state that a redeploy can invalidate. The session-id is effectively meaningless and claude.ai's reuse of an old one no longer breaks anything.

Safe for this MCP's surface:
- 6 read-only tool calls
- No resources, no sampling, no server→client notifications
- No streaming responses
- Token caching is in-process at the msal layer, not the MCP session layer

## Compat
No tool API change. No env / compose / gateway change. Single container redeploy.

## Test plan
- [ ] CI build green.
- [ ] Deploy succeeds; container starts cleanly.
- [ ] User retries the same questions in the same claude.ai chat (no disconnect/reconnect needed) — all tool calls should succeed.

## Follow-up (not in this PR)
GA4 / GSC / instagram / facebook use `stateless=False` in their manually-mounted session managers. They are theoretically vulnerable to the same stale-session issue after a redeploy. Worth a survey if it ever surfaces — could mirror this fix or add 400→404 middleware as a defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)