### PR TITLE
feat(tiktok-organic): MCP for Choiz TikTok account stats + recent videos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -143,3 +143,32 @@ PBI_CLIENT_SECRET=
 PBI_WORKSPACE_ID=cf1f61e8-81f5-4585-89a5-06e1397d8693
 PBI_DATASET_CHOIZ=6338c71a-2324-4fde-9941-c298728b371f
 PBI_DATASET_TIMELESS=92cbd3e9-ae15-44d6-a35d-a5426e70f205
+
+# --- TikTok Organic MCP (Choiz only at launch; Timeless slot reserved) ---
+#
+# Read-only access to a brand's TikTok account via Display API v2
+# (open.tiktokapis.com). End users authenticate to claude.ai with Google
+# Workspace; the refresh_token below is what talks to TikTok on their
+# behalf — they never see a TikTok login.
+#
+# How to mint / rotate:
+#   1. TikTok for Developers → your app → Manage apps → pick the
+#      Choiz app. Currently using the SANDBOX app (client_key starts
+#      with `sb`); sandbox returns real owned-content for the linked
+#      account, which is exactly what we want.
+#   2. Run the OAuth Authorization-Code flow with redirect URI from
+#      the app config + scopes:
+#        user.info.basic, user.info.profile, user.info.stats, video.list
+#      Capture the refresh_token from the /v2/oauth/token/ response.
+#   3. Update TIKTOK_CHOIZ_REFRESH_TOKEN below and restart the stack.
+#
+# Token lifetime:
+#   * access_token  — 24h, cached + refreshed in-process. Never persisted.
+#   * refresh_token — ~365d (28,151,737 seconds observed 2026-05-19),
+#     does NOT rotate on refresh. Schedule manual re-mint in ~10 months.
+#
+# Scopes used by the MCP tools (read-only):
+#   user.info.basic, user.info.profile, user.info.stats, video.list
+TIKTOK_CHOIZ_CLIENT_KEY=
+TIKTOK_CHOIZ_CLIENT_SECRET=
+TIKTOK_CHOIZ_REFRESH_TOKEN=

--- a/.github/workflows/deploy-gateway.yml
+++ b/.github/workflows/deploy-gateway.yml
@@ -53,6 +53,7 @@ jobs:
       gsc: ${{ steps.filter.outputs.gsc }}
       shopify: ${{ steps.filter.outputs.shopify }}
       powerbi: ${{ steps.filter.outputs.powerbi }}
+      tiktok_organic: ${{ steps.filter.outputs.tiktok_organic }}
       compose: ${{ steps.filter.outputs.compose }}
     steps:
       - uses: actions/checkout@v4
@@ -80,6 +81,8 @@ jobs:
               - 'mcp/shopify/**'
             powerbi:
               - 'mcp/powerbi/**'
+            tiktok_organic:
+              - 'mcp/tiktok-organic/**'
             compose:
               - 'compose.yml'
 
@@ -355,13 +358,40 @@ jobs:
           cache-from: type=gha,scope=powerbi
           cache-to: type=gha,mode=max,scope=powerbi
 
+  build-tiktok-organic:
+    name: Build tiktok-organic image
+    needs: changes
+    if: needs.changes.outputs.tiktok_organic == 'true' || needs.changes.outputs.compose == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./mcp/tiktok-organic
+          push: true
+          platforms: linux/arm64
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/tiktok-organic:latest
+            ${{ env.IMAGE_PREFIX }}/tiktok-organic:${{ github.sha }}
+          cache-from: type=gha,scope=tiktok-organic
+          cache-to: type=gha,mode=max,scope=tiktok-organic
+
   deploy:
     name: Deploy on EC2 via SSM
-    needs: [build-gateway, build-warehouse, build-meta-ads, build-facebook, build-instagram, build-google-ads, build-ga4, build-gsc, build-shopify, build-powerbi]
+    needs: [build-gateway, build-warehouse, build-meta-ads, build-facebook, build-instagram, build-google-ads, build-ga4, build-gsc, build-shopify, build-powerbi, build-tiktok-organic]
     # Run only if at least one build succeeded. If all builds were skipped
     # (because nothing relevant changed, e.g. workflow-only edit), do not
     # touch the EC2 — there's nothing to deploy.
-    if: ${{ !cancelled() && !failure() && (needs.build-gateway.result == 'success' || needs.build-warehouse.result == 'success' || needs.build-meta-ads.result == 'success' || needs.build-facebook.result == 'success' || needs.build-instagram.result == 'success' || needs.build-google-ads.result == 'success' || needs.build-ga4.result == 'success' || needs.build-gsc.result == 'success' || needs.build-shopify.result == 'success' || needs.build-powerbi.result == 'success') }}
+    if: ${{ !cancelled() && !failure() && (needs.build-gateway.result == 'success' || needs.build-warehouse.result == 'success' || needs.build-meta-ads.result == 'success' || needs.build-facebook.result == 'success' || needs.build-instagram.result == 'success' || needs.build-google-ads.result == 'success' || needs.build-ga4.result == 'success' || needs.build-gsc.result == 'success' || needs.build-shopify.result == 'success' || needs.build-powerbi.result == 'success' || needs.build-tiktok-organic.result == 'success') }}
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials

--- a/compose.yml
+++ b/compose.yml
@@ -38,6 +38,7 @@ services:
       UPSTREAM_SHOPIFY_TIMELESS: "http://shopify_timeless_mcp:8080"
       UPSTREAM_POWERBI_CHOIZ: "http://powerbi_choiz_mcp:8080"
       UPSTREAM_POWERBI_TIMELESS: "http://powerbi_timeless_mcp:8080"
+      UPSTREAM_TIKTOK_ORGANIC_CHOIZ: "http://tiktok_organic_choiz_mcp:8080"
       # Remote MCPs proxied through the gateway (no internal container).
       # The route is only registered if the corresponding API key is set;
       # gateway/src/index.ts logs a skip-warning otherwise. See memory
@@ -69,6 +70,7 @@ services:
       - google_ads_mcp
       - powerbi_choiz_mcp
       - powerbi_timeless_mcp
+      - tiktok_organic_choiz_mcp
     restart: unless-stopped
 
   warehouse_mcp:
@@ -303,4 +305,32 @@ services:
       PBI_WORKSPACE_ID: ${PBI_WORKSPACE_ID:?set PBI_WORKSPACE_ID in .env}
       PBI_DATASET_ID: ${PBI_DATASET_TIMELESS:?set PBI_DATASET_TIMELESS in .env}
       PBI_BRAND: timeless
+    restart: unless-stopped
+
+  # TikTok Organic MCP — multi-tenant-ready (one image, one container per
+  # brand), matches the powerbi / ga4 / facebook / instagram split. Each
+  # container is pinned to a single brand via TIKTOK_BRAND + a long-lived
+  # refresh_token in env; the MCP `name` surfaces as
+  # "tiktok-organic-choiz" in claude.ai so the LLM can't pick the wrong
+  # brand at tool-call time.
+  #
+  # Auth: TikTok Display API v2 OAuth. refresh_token is static (~365-day
+  # TTL, does not rotate on refresh in our experience). access_token is
+  # cached in-process and silently re-minted ~5 min before its 24h
+  # expiry. No tokens.json — the legacy local server's filesystem
+  # persistence is dropped. If the refresh_token expires we re-mint
+  # manually in the Developer Portal and rotate the .env value via SSM.
+  #
+  # Only Choiz at launch (2026-05-19). To add Timeless: register the
+  # Timeless TikTok account in the Dev Portal, mint a refresh_token,
+  # add tiktok_organic_timeless_mcp here + an UPSTREAM_TIKTOK_ORGANIC_TIMELESS
+  # entry in the gateway env + a /mcp/tiktok-organic-timeless route in
+  # gateway/src/index.ts. Container code is brand-agnostic, no rebuild needed.
+  tiktok_organic_choiz_mcp:
+    image: ghcr.io/choizapp/choiz-mcp-gateway/tiktok-organic:${IMAGE_TAG:-latest}
+    environment:
+      TIKTOK_CLIENT_KEY: ${TIKTOK_CHOIZ_CLIENT_KEY:?set TIKTOK_CHOIZ_CLIENT_KEY in .env}
+      TIKTOK_CLIENT_SECRET: ${TIKTOK_CHOIZ_CLIENT_SECRET:?set TIKTOK_CHOIZ_CLIENT_SECRET in .env}
+      TIKTOK_REFRESH_TOKEN: ${TIKTOK_CHOIZ_REFRESH_TOKEN:?set TIKTOK_CHOIZ_REFRESH_TOKEN in .env}
+      TIKTOK_BRAND: choiz
     restart: unless-stopped

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -30,6 +30,12 @@ const upstreams: Record<string, string | undefined> = {
   // The previous single `/mcp/powerbi` route was retired on 2026-05-19.
   "/mcp/powerbi-choiz":      process.env.UPSTREAM_POWERBI_CHOIZ,
   "/mcp/powerbi-timeless":   process.env.UPSTREAM_POWERBI_TIMELESS,
+  // TikTok Organic MCP — read-only access to a brand's TikTok account
+  // (Display API v2 owned-content). Server-side OAuth via long-lived
+  // refresh_token; end users only see Google Workspace login. Slug-by-brand
+  // for the same reason as powerbi (avoids LLM picking the wrong tenant).
+  // Choiz only at launch; Timeless slot pending Dev Portal app + tokens.
+  "/mcp/tiktok-organic-choiz": process.env.UPSTREAM_TIKTOK_ORGANIC_CHOIZ,
 };
 
 // --- Remote MCPs proxied through the gateway (no internal container) ---

--- a/mcp/tiktok-organic/Dockerfile
+++ b/mcp/tiktok-organic/Dockerfile
@@ -1,0 +1,33 @@
+# TikTok Organic MCP — custom server, no upstream package to wrap.
+#
+# Talks to TikTok Display API v2 (open.tiktokapis.com) using a long-lived
+# refresh_token kept in env. End users authenticate to claude.ai with
+# Google Workspace; they never see a TikTok login.
+#
+# Multi-tenant pattern (one image, one container per brand): TIKTOK_BRAND
+# + TIKTOK_CLIENT_KEY/SECRET/REFRESH_TOKEN per-container. Matches ga4 /
+# gsc / facebook / instagram / shopify / powerbi slug-by-brand convention.
+
+FROM python:3.12-slim
+
+# ca-certificates: HTTPS to open.tiktokapis.com.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Pin mcp to 1.25.0 to match the rest of the stack (warehouse / facebook /
+# instagram / ga4 / powerbi). requests for the TikTok HTTP calls — no SDK
+# needed, the surface we use is six REST endpoints and one OAuth refresh.
+RUN pip install --no-cache-dir \
+    'mcp==1.25.0' \
+    'requests>=2.31,<3'
+
+ENV PYTHONUNBUFFERED=1
+
+COPY entrypoint.py /opt/entrypoint.py
+
+EXPOSE 8080
+
+ENTRYPOINT ["python", "/opt/entrypoint.py"]

--- a/mcp/tiktok-organic/entrypoint.py
+++ b/mcp/tiktok-organic/entrypoint.py
@@ -1,0 +1,415 @@
+"""TikTok Organic MCP — read-only access to ONE TikTok account's owned content.
+
+Single-tenant by design (since 2026-05-19, mirrors the powerbi split): the
+refresh token and brand label are pre-configured per-container via env vars.
+A second tenant (e.g. timeless) gets its own container under the same image,
+exposed at a different slug (/mcp/tiktok-organic-timeless/). This matches the
+ga4-choiz / ga4-timeless / powerbi-choiz / powerbi-timeless convention and
+keeps the LLM from picking the wrong brand at tool-call time.
+
+End users authenticate to claude.ai with Google Workspace. The gateway routes
+their request here; this container talks to TikTok Display API v2 using a
+long-lived refresh_token kept in env. End users never see a TikTok login.
+
+Tool surface (read-only):
+  - get_account_info()                 : profile + counts (followers, videos, likes)
+  - get_latest_videos(max_count=10)    : recent posts + engagement metrics
+  - get_video_details(video_id)        : detail + engagement for one video
+  - validate_token()                   : ping the API; refresh in-memory if needed
+
+Auth model:
+  TikTok Display API v2 OAuth.
+    * access_token  : 24-hour TTL. Refreshed in-process on-demand.
+    * refresh_token : ~365-day TTL, does NOT rotate on refresh in our
+      experience (see project_tiktok_organic_deployed_state). Static env
+      var; rotate manually before expiry by re-authorizing in the TikTok
+      Developer Portal.
+  The container NEVER writes tokens to disk. The local server.py used a
+  tokens.json file; that pattern is incompatible with an ephemeral
+  container and is dropped here. A new refresh_token returned by TikTok
+  (should it ever rotate) is logged + discarded; if refresh starts to
+  fail because of rotation, we re-mint manually.
+
+Payload-ceiling discipline (see project_claudeai_payload_ceiling):
+  list responses default to small page sizes and trim heavy fields
+  (cover_image_url, full descriptions). get_video_details returns
+  everything for one video, which stays comfortably under the ceiling.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Any
+
+import requests
+from mcp.server.fastmcp import FastMCP
+
+logger = logging.getLogger("tiktok_organic_mcp")
+logging.basicConfig(
+    level=os.environ.get("LOG_LEVEL", "INFO"),
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+
+# --- Config from env (all required except BRAND) --------------------------
+
+CLIENT_KEY = os.environ["TIKTOK_CLIENT_KEY"]
+CLIENT_SECRET = os.environ["TIKTOK_CLIENT_SECRET"]
+REFRESH_TOKEN = os.environ["TIKTOK_REFRESH_TOKEN"]
+# Short label baked into the MCP `name` so claude.ai surfaces it as
+# "tiktok-organic-choiz" instead of a generic "tiktok-organic".
+BRAND = os.environ.get("TIKTOK_BRAND", "unknown")
+
+BASE_URL = "https://open.tiktokapis.com"
+
+# --- Token cache (in-process, thread-safe) --------------------------------
+#
+# TikTok access_tokens last 24h. We mint on first use and silently refresh
+# ~5 minutes before expiry on subsequent calls. No persistence — a redeploy
+# just re-mints from the static refresh_token in env.
+
+_token_lock = threading.Lock()
+_access_token: str | None = None
+_token_expires_at: float = 0.0  # epoch seconds
+
+
+def _refresh_access_token() -> str:
+    """Exchange the static refresh_token for a fresh access_token.
+
+    Mutates module globals under `_token_lock`. Returns the new access_token.
+    Raises RuntimeError if TikTok refuses the refresh — at that point the
+    refresh_token has likely expired (>365d since last re-auth) and
+    requires manual rotation in the Developer Portal.
+    """
+    global _access_token, _token_expires_at
+
+    resp = requests.post(
+        f"{BASE_URL}/v2/oauth/token/",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        data={
+            "client_key": CLIENT_KEY,
+            "client_secret": CLIENT_SECRET,
+            "grant_type": "refresh_token",
+            "refresh_token": REFRESH_TOKEN,
+        },
+        timeout=20,
+    )
+    data = resp.json()
+
+    if resp.status_code != 200 or "access_token" not in data:
+        raise RuntimeError(
+            f"refresh_access_token failed (HTTP {resp.status_code}): "
+            f"error={data.get('error')} description={data.get('error_description')}. "
+            "If this persists, the refresh_token has expired — re-authorize "
+            "in the TikTok Developer Portal and update TIKTOK_*_REFRESH_TOKEN."
+        )
+
+    new_access = data["access_token"]
+    expires_in = int(data.get("expires_in", 86400))
+    # Subtract a safety margin so we never serve a token within 5 min of expiry.
+    _access_token = new_access
+    _token_expires_at = time.time() + expires_in - 300
+
+    returned_refresh = data.get("refresh_token")
+    if returned_refresh and returned_refresh != REFRESH_TOKEN:
+        logger.warning(
+            "TikTok returned a rotated refresh_token; container env still holds "
+            "the previous one. If next refresh fails, update TIKTOK_*_REFRESH_TOKEN "
+            "in EC2 .env from the Developer Portal."
+        )
+    return new_access
+
+
+def _get_token() -> str:
+    """Return a non-expired access_token, refreshing under the lock if needed."""
+    global _access_token, _token_expires_at
+    with _token_lock:
+        if _access_token is None or time.time() >= _token_expires_at:
+            return _refresh_access_token()
+        return _access_token
+
+
+# --- TikTok API helpers ---------------------------------------------------
+
+# Error codes that mean "access_token bad", warranting one retry after refresh.
+RETRYABLE_ERROR_CODES = {
+    "access_token_invalid",
+    "token_expired",
+    "invalid_token",
+}
+
+
+def _api_request(
+    method: str,
+    endpoint: str,
+    *,
+    params: dict[str, Any] | None = None,
+    body: dict[str, Any] | None = None,
+    fields: list[str] | None = None,
+) -> dict[str, Any]:
+    """Make an authenticated request to TikTok Display API v2.
+
+    Retries once if the access_token is rejected — covers the edge case where
+    the cached token gets invalidated server-side before its expires_at.
+
+    Raises RuntimeError on non-2xx HTTP or on a non-retryable TikTok error,
+    so the LLM gets actionable feedback. Tools that want to surface the
+    error as a dict (not raise) can catch RuntimeError.
+    """
+    url = f"{BASE_URL}{endpoint}"
+    if fields:
+        params = dict(params or {})
+        params["fields"] = ",".join(fields)
+
+    for attempt in (1, 2):
+        token = _get_token()
+        headers = {"Authorization": f"Bearer {token}"}
+        if method == "POST":
+            headers["Content-Type"] = "application/json"
+            resp = requests.post(
+                url, headers=headers, params=params, json=body or {}, timeout=30
+            )
+        else:
+            resp = requests.get(url, headers=headers, params=params, timeout=30)
+
+        data = resp.json()
+        error = data.get("error", {}) or {}
+        code = error.get("code")
+
+        if code == "ok":
+            return data
+
+        if attempt == 1 and code in RETRYABLE_ERROR_CODES:
+            # Force a re-mint on the next call.
+            global _token_expires_at
+            with _token_lock:
+                _token_expires_at = 0.0
+            continue
+
+        raise RuntimeError(
+            f"TikTok API error on {method} {endpoint}: code={code} "
+            f"message={error.get('message')} log_id={error.get('log_id')}"
+        )
+
+    # Unreachable: the for-loop either returns or raises.
+    raise RuntimeError("unreachable")
+
+
+def _truncate(s: Any, n: int) -> Any:
+    """Trim long strings to keep responses under claude.ai's payload ceiling."""
+    if isinstance(s, str) and len(s) > n:
+        return s[: n - 1] + "…"
+    return s
+
+
+# --- MCP server -----------------------------------------------------------
+
+# host="0.0.0.0" so the gateway can reach us across the docker bridge with
+#   Host: tiktok_organic_*_mcp:8080 (changeOrigin: true). FastMCP otherwise
+#   auto-enables DNS rebinding protection that rejects non-localhost Host
+#   headers — same gotcha as powerbi / warehouse.
+# streamable_http_path="/" so the gateway can strip /mcp/tiktok-organic-<brand>
+#   and forward to "/".
+# stateless_http=True: every request is an ephemeral session. Sidesteps the
+#   post-redeploy "stale Mcp-Session-Id" failure mode
+#   (feedback_stale_session_after_redeploy).
+mcp = FastMCP(
+    name=f"tiktok-organic-{BRAND}",
+    host="0.0.0.0",
+    port=8080,
+    streamable_http_path="/",
+    stateless_http=True,
+)
+
+
+@mcp.tool()
+def get_account_info() -> dict[str, Any]:
+    """Get this brand's TikTok account profile + lifetime counts.
+
+    Returns: display_name, bio_description, follower_count, following_count,
+    likes_count (lifetime), video_count. The avatar_url is omitted (heavy,
+    not useful for LLM reasoning).
+
+    Note: the Display API does NOT expose date-ranged engagement metrics,
+    only lifetime totals. For per-video engagement use `get_latest_videos`
+    or `get_video_details`.
+    """
+    data = _api_request(
+        "GET",
+        "/v2/user/info/",
+        fields=[
+            "display_name",
+            "bio_description",
+            "follower_count",
+            "following_count",
+            "likes_count",
+            "video_count",
+        ],
+    )
+    user = data.get("data", {}).get("user", {})
+    return {"brand": BRAND, **user}
+
+
+@mcp.tool()
+def get_latest_videos(
+    max_count: int = 10,
+    include_cover_url: bool = False,
+) -> dict[str, Any]:
+    """Get this brand's most recent TikTok videos with engagement metrics.
+
+    Paginates /v2/video/list/ in pages of 20 (TikTok's max page size) until
+    `max_count` is reached, then fetches engagement metrics in batches of 20
+    via /v2/video/query/.
+
+    Trimmed by default to stay under claude.ai's payload ceiling:
+      * default max_count=10 (vs 20 in the legacy local server)
+      * descriptions truncated to ~200 chars
+      * cover_image_url omitted unless `include_cover_url=True`
+
+    Each video carries: id, title, video_description (trimmed), duration,
+    create_time (epoch seconds), view_count, like_count, comment_count,
+    share_count. Engagement values are lifetime totals — the Display API
+    does not support date-range filtering.
+    """
+    max_count = max(1, min(int(max_count), 100))
+
+    # Step 1 — paginate /video/list/.
+    all_videos: list[dict[str, Any]] = []
+    cursor = 0
+    while len(all_videos) < max_count:
+        page_size = min(20, max_count - len(all_videos))
+        list_result = _api_request(
+            "POST",
+            "/v2/video/list/",
+            fields=[
+                "id",
+                "title",
+                "video_description",
+                "duration",
+                "cover_image_url",
+                "create_time",
+            ],
+            body={"max_count": page_size, "cursor": cursor},
+        )
+        page_videos = list_result.get("data", {}).get("videos", [])
+        if not page_videos:
+            break
+        all_videos.extend(page_videos)
+        has_more = list_result.get("data", {}).get("has_more", False)
+        if not has_more:
+            break
+        cursor = list_result["data"]["cursor"]
+
+    if not all_videos:
+        return {"brand": BRAND, "videos": [], "count": 0}
+
+    # Step 2 — fetch engagement metrics in batches of 20.
+    metrics_by_id: dict[str, dict[str, Any]] = {}
+    for i in range(0, len(all_videos), 20):
+        batch_ids = [v["id"] for v in all_videos[i : i + 20]]
+        query_result = _api_request(
+            "POST",
+            "/v2/video/query/",
+            fields=["id", "view_count", "like_count", "comment_count", "share_count"],
+            body={"filters": {"video_ids": batch_ids}},
+        )
+        for v in query_result.get("data", {}).get("videos", []):
+            metrics_by_id[v["id"]] = v
+
+    # Step 3 — merge + trim heavy fields.
+    merged: list[dict[str, Any]] = []
+    for video in all_videos:
+        entry: dict[str, Any] = {
+            "id": video.get("id"),
+            "title": _truncate(video.get("title"), 100),
+            "video_description": _truncate(video.get("video_description"), 200),
+            "duration": video.get("duration"),
+            "create_time": video.get("create_time"),
+        }
+        if include_cover_url:
+            entry["cover_image_url"] = video.get("cover_image_url")
+        metrics = metrics_by_id.get(video["id"], {})
+        entry["view_count"] = metrics.get("view_count", 0)
+        entry["like_count"] = metrics.get("like_count", 0)
+        entry["comment_count"] = metrics.get("comment_count", 0)
+        entry["share_count"] = metrics.get("share_count", 0)
+        merged.append(entry)
+
+    return {"brand": BRAND, "videos": merged, "count": len(merged)}
+
+
+@mcp.tool()
+def get_video_details(video_id: str) -> dict[str, Any]:
+    """Get detailed information + engagement for a single TikTok video by ID.
+
+    Single-video payload is small enough to return all available fields
+    without trimming. Use this after `get_latest_videos` when you need
+    extra detail on a specific post.
+
+    Returns: id, title, video_description, duration, height, width,
+    cover_image_url, share_url, embed_link, create_time, view_count,
+    like_count, comment_count, share_count.
+    """
+    data = _api_request(
+        "POST",
+        "/v2/video/query/",
+        fields=[
+            "id",
+            "title",
+            "video_description",
+            "duration",
+            "height",
+            "width",
+            "cover_image_url",
+            "share_url",
+            "embed_link",
+            "create_time",
+            "view_count",
+            "like_count",
+            "comment_count",
+            "share_count",
+        ],
+        body={"filters": {"video_ids": [video_id]}},
+    )
+    videos = data.get("data", {}).get("videos", [])
+    if not videos:
+        raise RuntimeError(f"video {video_id} not found")
+    return {"brand": BRAND, **videos[0]}
+
+
+@mcp.tool()
+def validate_token() -> dict[str, Any]:
+    """Ping TikTok with the current access_token + report cache state.
+
+    Useful for debugging "is this MCP healthy" without exercising a real
+    endpoint. Does NOT write to disk. If the cached token is expired,
+    forces an in-memory refresh as a side effect.
+    """
+    # Force a refresh-if-needed pass + a lightweight call.
+    data = _api_request("GET", "/v2/user/info/", fields=["open_id"])
+    open_id = data.get("data", {}).get("user", {}).get("open_id")
+    seconds_left = max(0, int(_token_expires_at - time.time()))
+    return {
+        "brand": BRAND,
+        "valid": True,
+        "open_id_present": bool(open_id),
+        "access_token_seconds_remaining": seconds_left,
+    }
+
+
+def main() -> None:
+    logger.info("tiktok-organic mcp starting — brand=%s", BRAND)
+    try:
+        _get_token()
+        logger.info("initial token acquisition OK")
+    except Exception as exc:  # pragma: no cover — startup probe
+        logger.error("initial token acquisition FAILED: %s", exc)
+        # Don't exit: a transient TikTok 5xx at boot shouldn't kill the
+        # container. First tool call will retry.
+
+    mcp.run(transport="streamable-http")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- New container `tiktok-organic-choiz` exposed at `/mcp/tiktok-organic-choiz/`. Mirrors the powerbi multi-tenant slug pattern.
- Wraps TikTok **Display API v2** (owned-content of the linked TikTok account). Read-only — scopes `user.info.{basic,profile,stats}`, `video.list`.
- Server-side OAuth via long-lived refresh_token in env. End users only see Google Workspace login.
- 4 tools: `get_account_info`, `get_latest_videos`, `get_video_details`, `validate_token`. Responses trimmed for claude.ai payload ceiling.

## Why this approach

- **No native Anthropic connector exists** for TikTok. Third-party SaaS options (Porter, Windsor) would add commercial dependency and intermediate the data — declined.
- **No public OSS MCP** exists for TikTok owned-content. Existing public TikTok MCPs are either scraping (Seym0n) or paid-ads (AdsMCP/ysntony) — wrong scope.
- **Local server.py** (`~/Documents/tiktok-organic-mcp`) was the only viable starting point. Ported following the powerbi pattern (FastMCP + `stateless_http=True` + StreamableHTTPSessionManager + uvicorn).

## Validated empirically before building

Standalone POC ran on 2026-05-19 against the sandbox app (client_key prefix `sb…`):
- Refresh flow: HTTP 200, returns `access_token` + stable `refresh_token` + scopes.
- `/v2/user/info/`: returns real Choiz account data (8,253 followers, 176 videos).
- `/v2/video/list/`: returns 5 real owned videos with engagement metrics.
- `refresh_expires_in = 28,151,737s` (~326 days) — refresh_token does **not** rotate on refresh. Schedule manual re-mint ~apr 2027.

## Files touched (all additive — no existing behavior changed)

- `mcp/tiktok-organic/entrypoint.py` (new) — FastMCP server, 4 tools, in-memory token cache.
- `mcp/tiktok-organic/Dockerfile` (new) — Python 3.12-slim, `mcp==1.25.0`.
- `compose.yml` — new service `tiktok_organic_choiz_mcp` + `UPSTREAM_TIKTOK_ORGANIC_CHOIZ` + `depends_on` entry.
- `gateway/src/index.ts` — one new line in the `upstreams` routing table.
- `.env.example` — new section documenting the three secrets to set in EC2.
- `.github/workflows/deploy-gateway.yml` — `build-tiktok-organic` job + filter + deploy gate.

## Deploy steps (you trigger these)

1. Set the three secrets on EC2 via SSM (from this branch's `.env.example` section):
   - `TIKTOK_CHOIZ_CLIENT_KEY`
   - `TIKTOK_CHOIZ_CLIENT_SECRET`
   - `TIKTOK_CHOIZ_REFRESH_TOKEN`
2. Merge this PR (or run `gh workflow run deploy-gateway.yml` from this branch).
3. CI builds `tiktok-organic` image (ARM64) → GHCR, then SSM deploys via `docker compose pull && up -d`.
4. Verify: `curl https://mcp.choiz.com.mx/healthz` should list `/mcp/tiktok-organic-choiz` in `routes`.
5. In claude.ai → Connectors → Add custom connector → paste `https://mcp.choiz.com.mx/mcp/tiktok-organic-choiz/`.

## Adding Timeless later (when Dev Portal app exists)

One PR with: new service `tiktok_organic_timeless_mcp` in `compose.yml`, `UPSTREAM_TIKTOK_ORGANIC_TIMELESS` env + depends_on, `/mcp/tiktok-organic-timeless` line in `gateway/src/index.ts`, three new env vars in `.env.example`. Container code is brand-agnostic — no image rebuild needed.

## Test plan

- [ ] CI green (build-tiktok-organic + all other build jobs unchanged).
- [ ] `docker compose config` validates locally (✅ done on this branch).
- [ ] After deploy: `/healthz` lists the new route.
- [ ] After deploy: `validate_token` returns `valid=true` + non-zero `access_token_seconds_remaining`.
- [ ] After deploy: `get_account_info` returns the Choiz brand profile.
- [ ] After deploy: `get_latest_videos(max_count=5)` returns 5 real videos with engagement.
- [ ] Other MCPs (warehouse, ga4, gsc, facebook, instagram, meta-ads, google-ads, shopify, powerbi-choiz, powerbi-timeless, kapso) still respond on `/healthz`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)