### PR TITLE
fix(gsc): per-session McpServer + transport (multi-client support)

### DIFF
--- a/mcp/gsc/entrypoint.mjs
+++ b/mcp/gsc/entrypoint.mjs
@@ -1,22 +1,39 @@
 // GSC MCP entrypoint — serves ahonn/mcp-server-gsc via streamable-http
-// without supergateway.
+// without supergateway, using the canonical MCP TS SDK per-session pattern.
 //
 // The upstream package's `src/index.ts` ships only a stdio launcher; its
 // `src/remote.ts` is a Cloudflare Workers / Hono variant that doesn't
 // bind to a Node port. Both reuse `createServer(credentials): Server`
-// from `src/server.ts`. We import that builder and wire it through the
-// MCP TS SDK's `StreamableHTTPServerTransport`, then bind a plain Node
-// HTTP server on 0.0.0.0:8080. Same architectural shape as
-// mcp/instagram/entrypoint.py and mcp/ga4/entrypoint.py — single
-// in-process server, no per-request child churn.
+// from `src/server.ts`. That builder instantiates a fresh `Server` per
+// call (no shared state across calls — verified upstream at SHA
+// e671b155), so it's safe to invoke once per MCP session.
 //
-// Auth: same Choiz `ga4-mcp-reader` service-account JSON as GA4 + GSC
-// historically. The base64 form arrives via `GSC_SERVICE_ACCOUNT_JSON_B64`
-// (compose-level alias of `GA4_SERVICE_ACCOUNT_JSON_B64`); we decode it
-// once at startup to /tmp/gsc-sa.json and pass the path to createServer.
+// Architecture (canonical MCP TS SDK session pattern — same shape as
+// mcp/shopify/entrypoint.mjs post-PR #21):
+//   * Module-level: the service-account JSON is decoded once to disk.
+//     The path is stateless w.r.t. MCP sessions and shared across all.
+//   * Per HTTP session: a fresh `Server` from `createServer(path)` +
+//     fresh `StreamableHTTPServerTransport`, stored in `transports`
+//     keyed by Mcp-Session-Id. Sharing a single Server across sessions
+//     causes "Server already initialized" on the second `initialize`
+//     request — surfaces in claude.ai as a generic "Authorization
+//     failed + ofid_..." error.
+//
+// Why the rewrite: smoke test on 2026-05-19 (post tiktok-organic deploy)
+// hit `gsc-choiz` with HTTP 400 "Invalid Request: Server already
+// initialized" on a fresh initialize call. The pre-existing single-
+// shared-Server pattern was already documented as a latent bug
+// (project_gsc_latent_session_bug). This change applies the fix.
+//
+// Auth: Choiz `ga4-mcp-reader` service-account JSON arrives via
+// `GSC_SERVICE_ACCOUNT_JSON_B64` (compose-level alias of
+// `GA4_SERVICE_ACCOUNT_JSON_B64`); decoded once at startup to
+// /tmp/gsc-sa.json (chmod 600) and the path is passed into
+// createServer() per session.
 
 import { createServer } from "./dist/server.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { randomUUID } from "node:crypto";
 import { writeFileSync, chmodSync } from "node:fs";
 import http from "node:http";
@@ -32,55 +49,127 @@ function materializeServiceAccount() {
   return path;
 }
 
-async function main() {
-  const credentialsPath = materializeServiceAccount();
+const credentialsPath = materializeServiceAccount();
+console.error(`GSC MCP: credentials path=${credentialsPath}`);
 
-  // createServer registers the 8 tools (list_sites, search_analytics,
-  // enhanced_search_analytics, detect_quick_wins, index_inspect,
-  // list_sitemaps, get_sitemap, submit_sitemap) and returns a fully
-  // wired @modelcontextprotocol/sdk Server.
-  const server = createServer(credentialsPath);
+// Session-id -> transport. Each transport is bound to its own Server at
+// creation time. Cleared via transport.onclose when claude.ai
+// terminates the session (or it times out).
+const transports = Object.create(null);
 
-  // Stateful streamable-http: claude.ai opens parallel POST + GET SSE
-  // streams; the SDK's transport correctly multiplexes them by session.
-  // (Different from the supergateway --stateful flag tripped by bug #126
-  // — that bug was specific to supergateway's bridging logic.)
-  const transport = new StreamableHTTPServerTransport({
-    sessionIdGenerator: () => randomUUID(),
-  });
-
-  await server.connect(transport);
-
-  const httpServer = http.createServer(async (req, res) => {
-    try {
-      await transport.handleRequest(req, res);
-    } catch (err) {
-      console.error("handleRequest error:", err);
-      if (!res.headersSent) {
-        res.statusCode = 500;
-        res.setHeader("content-type", "application/json");
-        res.end(JSON.stringify({ error: String(err) }));
-      } else {
-        res.end();
+async function readJsonBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => {
+      if (chunks.length === 0) return resolve(undefined);
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString("utf8")));
+      } catch (err) {
+        reject(err);
       }
-    }
-  });
-
-  httpServer.listen(8080, "0.0.0.0", () => {
-    console.error("GSC MCP listening on http://0.0.0.0:8080/");
-  });
-
-  // Graceful shutdown so docker compose stop sends SIGTERM and we exit
-  // cleanly (otherwise compose waits the 10s default timeout).
-  for (const sig of ["SIGINT", "SIGTERM"]) {
-    process.on(sig, () => {
-      console.error(`Received ${sig}, shutting down`);
-      httpServer.close(() => process.exit(0));
     });
-  }
+    req.on("error", reject);
+  });
 }
 
-main().catch((err) => {
-  console.error("Fatal:", err);
-  process.exit(1);
+function send400(res, message) {
+  if (res.headersSent) return;
+  res.statusCode = 400;
+  res.setHeader("content-type", "application/json");
+  res.end(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      error: { code: -32000, message },
+      id: null,
+    }),
+  );
+}
+
+async function handle(req, res) {
+  const sessionId = req.headers["mcp-session-id"];
+  const method = req.method || "GET";
+
+  if (method === "POST") {
+    let body;
+    try {
+      body = await readJsonBody(req);
+    } catch (err) {
+      send400(res, `Invalid JSON body: ${String(err)}`);
+      return;
+    }
+
+    let transport;
+    if (sessionId && transports[sessionId]) {
+      transport = transports[sessionId];
+    } else if (!sessionId && body && isInitializeRequest(body)) {
+      transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        onsessioninitialized: (id) => {
+          transports[id] = transport;
+          console.error(`session ${id} initialized`);
+        },
+      });
+      transport.onclose = () => {
+        const sid = transport.sessionId;
+        if (sid && transports[sid]) {
+          delete transports[sid];
+          console.error(`session ${sid} closed`);
+        }
+      };
+      // Fresh Server per session — see file header.
+      const server = createServer(credentialsPath);
+      await server.connect(transport);
+      await transport.handleRequest(req, res, body);
+      return;
+    } else {
+      send400(res, "Bad Request: No valid session ID provided");
+      return;
+    }
+    await transport.handleRequest(req, res, body);
+    return;
+  }
+
+  if (method === "GET" || method === "DELETE") {
+    if (!sessionId || !transports[sessionId]) {
+      send400(res, "Invalid or missing session ID");
+      return;
+    }
+    await transports[sessionId].handleRequest(req, res);
+    return;
+  }
+
+  res.statusCode = 405;
+  res.setHeader("allow", "GET, POST, DELETE");
+  res.end();
+}
+
+const httpServer = http.createServer(async (req, res) => {
+  try {
+    await handle(req, res);
+  } catch (err) {
+    console.error("handleRequest error:", err);
+    if (!res.headersSent) {
+      res.statusCode = 500;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ error: String(err) }));
+    } else {
+      try {
+        res.end();
+      } catch {}
+    }
+  }
 });
+
+httpServer.listen(8080, "0.0.0.0", () => {
+  console.error("GSC MCP listening on http://0.0.0.0:8080/");
+});
+
+// Graceful shutdown so `docker compose stop` sends SIGTERM and we exit
+// cleanly (otherwise compose waits the 10s default timeout).
+for (const sig of ["SIGINT", "SIGTERM"]) {
+  process.on(sig, () => {
+    console.error(`Received ${sig}, shutting down`);
+    httpServer.close(() => process.exit(0));
+  });
+}


### PR DESCRIPTION
## Problem

Smoke test on 2026-05-19 (post tiktok-organic deploy, [PR #31](https://github.com/Choizapp/choiz-mcp-gateway/pull/31)) hit `gsc-choiz` with:

```
HTTP 400 {"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid Request: Server already initialized"...}}
```

`gsc-timeless` returned 200 in the same run only because it happened to have no live session at that moment. Both containers share the latent bug.

## Root cause

The pre-existing `mcp/gsc/entrypoint.mjs` builds **one** `Server` + **one** `StreamableHTTPServerTransport` at startup and routes every incoming HTTP request through the same transport. The MCP SDK only accepts a single `initialize` per `Server` instance; the second one (whether a parallel client or a reconnect) is rejected.

This was already documented as a latent risk — memory `project_gsc_latent_session_bug.md` says: *"GSC may have the same latent single-session bug — fix template lives in mcp/shopify/entrypoint.mjs post-PR #21"*. This PR applies that fix.

## Fix

Canonical MCP TS SDK session pattern, copied 1:1 from `mcp/shopify/entrypoint.mjs`:

- **Module-level** (stateless w.r.t. MCP sessions): decode the SA JSON to `/tmp/gsc-sa.json` once. Same as before.
- **Per HTTP session**: fresh `Server` from `createServer(credentialsPath)` + fresh `StreamableHTTPServerTransport`, stored in a `transports` map keyed by `Mcp-Session-Id`. Cleanup on `transport.onclose`.

Upstream safety: `ahonn/mcp-server-gsc@e671b155` `createServer()` instantiates a brand-new SDK `Server` each call (no shared state); running N in parallel is fine.

## Diff shape

| Component | Before | After |
|---|---|---|
| `materializeServiceAccount()` | once at startup | unchanged (still once) |
| `createServer(credentialsPath)` | once at startup | **per session** |
| `StreamableHTTPServerTransport` | one global, infinite reuse | **per session, keyed by session id** |
| HTTP handler | single `transport.handleRequest(req, res)` | `handle(req, res)` dispatcher: POST initialize → new transport; POST/GET/DELETE with session id → reuse |

## Test plan

After CI build + deploy:

- [ ] Two concurrent `initialize` calls to `/mcp/gsc-choiz/` from SSM both return HTTP 200 with distinct `Mcp-Session-Id` headers.
- [ ] Same against `/mcp/gsc-timeless/`.
- [ ] `tools/list` after each initialize returns the 8 GSC tools.
- [ ] Other MCPs (warehouse, ga4-*, facebook-*, instagram-*, meta-ads, google-ads, shopify-*, powerbi-*, kapso, tiktok-organic-choiz) unaffected by the redeploy.
- [ ] If smoke green: dedup `gsc-choiz` + `gsc-timeless` entries from Claude Desktop config into `mcpServers_disabled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)