### PR TITLE
fix(compose): pass per-project KAPSO_API_KEY_* env vars to gateway

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -43,7 +43,10 @@ services:
       # The route is only registered if the corresponding API key is set;
       # gateway/src/index.ts logs a skip-warning otherwise. See memory
       # project_wrap_remote_mcps + the remoteUpstreams table in index.ts.
-      KAPSO_API_KEY: ${KAPSO_API_KEY:-}
+      KAPSO_API_KEY_CHOIZ_SALES:      ${KAPSO_API_KEY_CHOIZ_SALES:-}
+      KAPSO_API_KEY_CHOIZ_SUPPORT:    ${KAPSO_API_KEY_CHOIZ_SUPPORT:-}
+      KAPSO_API_KEY_TIMELESS_SALES:   ${KAPSO_API_KEY_TIMELESS_SALES:-}
+      KAPSO_API_KEY_TIMELESS_SUPPORT: ${KAPSO_API_KEY_TIMELESS_SUPPORT:-}
       # Re-enabled 2026-05-07: cutover to the official googleads/google-ads-mcp
       # eliminates supergateway --stateless, so the original tunnel-zombie
       # trigger (per-request gRPC channel storm to googleads.googleapis.com)


### PR DESCRIPTION
## Summary
- Follow-up to #33. The gateway service in `compose.yml` uses an explicit `environment:` allowlist, so the four new `KAPSO_API_KEY_*` vars in `.env` were not reaching the container.
- Post-deploy `tunnel.choiz.com.mx/healthz` confirmed the four kapso slugs were silently skipped (no errors, just absent from the routes list).
- Replaces the now-removed `KAPSO_API_KEY` line with the four per-project pass-throughs.

## Test plan
- [ ] CI deploys.
- [ ] After deploy, `curl https://tunnel.choiz.com.mx/healthz | jq '.routes'` includes the four `kapso-*` routes.
- [ ] Smoke test one slug from claude.ai (`status` tool) returns the right project name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)