### PR TITLE
feat(dhl): MCP for DHL Express tracking + label/return generation (MyDHL API)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -179,3 +179,27 @@ PBI_DATASET_TIMELESS=92cbd3e9-ae15-44d6-a35d-a5426e70f205
 TIKTOK_CHOIZ_CLIENT_KEY=
 TIKTOK_CHOIZ_CLIENT_SECRET=
 TIKTOK_CHOIZ_REFRESH_TOKEN=
+
+# --- DHL Express MCP (single tenant; WRITE-capable) ---
+#
+# Wraps the MyDHL API (DHL Express REST). Tracking is read-only; create_shipment
+# / create_return_shipment GENERATE REAL LABELS and can bill the DHL account.
+# End users authenticate to claude.ai with Google Workspace; the Basic creds
+# below are what talk to DHL on their behalf.
+#
+# Auth: HTTP Basic = base64(DHL_API_KEY:DHL_API_SECRET). Get the API key/secret
+# from the DHL developer portal (developer.dhl.com) app bound to the DHL
+# Express account. Static — no token refresh.
+DHL_API_KEY=
+DHL_API_SECRET=
+
+# Environment selector. LEAVE BLANK for the MyDHL *test* base
+# (https://express.api.dhl.com/mydhlapi/test) — the safe default while
+# validating create-shipment payloads. Set to the production base only when
+# ready to book real shipments:
+#   DHL_BASE_URL=https://express.api.dhl.com/mydhlapi
+DHL_BASE_URL=
+
+# Optional: DHL Express account number (digits). Convenience reference only —
+# the account normally travels inside the shipment body's `accounts`, not a header.
+DHL_ACCOUNT_NUMBER=

--- a/.github/workflows/deploy-gateway.yml
+++ b/.github/workflows/deploy-gateway.yml
@@ -54,6 +54,7 @@ jobs:
       shopify: ${{ steps.filter.outputs.shopify }}
       powerbi: ${{ steps.filter.outputs.powerbi }}
       tiktok_organic: ${{ steps.filter.outputs.tiktok_organic }}
+      dhl: ${{ steps.filter.outputs.dhl }}
       compose: ${{ steps.filter.outputs.compose }}
     steps:
       - uses: actions/checkout@v4
@@ -83,6 +84,8 @@ jobs:
               - 'mcp/powerbi/**'
             tiktok_organic:
               - 'mcp/tiktok-organic/**'
+            dhl:
+              - 'mcp/dhl/**'
             compose:
               - 'compose.yml'
 
@@ -385,13 +388,40 @@ jobs:
           cache-from: type=gha,scope=tiktok-organic
           cache-to: type=gha,mode=max,scope=tiktok-organic
 
+  build-dhl:
+    name: Build dhl image
+    needs: changes
+    if: needs.changes.outputs.dhl == 'true' || needs.changes.outputs.compose == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./mcp/dhl
+          push: true
+          platforms: linux/arm64
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/dhl:latest
+            ${{ env.IMAGE_PREFIX }}/dhl:${{ github.sha }}
+          cache-from: type=gha,scope=dhl
+          cache-to: type=gha,mode=max,scope=dhl
+
   deploy:
     name: Deploy on EC2 via SSM
-    needs: [build-gateway, build-warehouse, build-meta-ads, build-facebook, build-instagram, build-google-ads, build-ga4, build-gsc, build-shopify, build-powerbi, build-tiktok-organic]
+    needs: [build-gateway, build-warehouse, build-meta-ads, build-facebook, build-instagram, build-google-ads, build-ga4, build-gsc, build-shopify, build-powerbi, build-tiktok-organic, build-dhl]
     # Run only if at least one build succeeded. If all builds were skipped
     # (because nothing relevant changed, e.g. workflow-only edit), do not
     # touch the EC2 — there's nothing to deploy.
-    if: ${{ !cancelled() && !failure() && (needs.build-gateway.result == 'success' || needs.build-warehouse.result == 'success' || needs.build-meta-ads.result == 'success' || needs.build-facebook.result == 'success' || needs.build-instagram.result == 'success' || needs.build-google-ads.result == 'success' || needs.build-ga4.result == 'success' || needs.build-gsc.result == 'success' || needs.build-shopify.result == 'success' || needs.build-powerbi.result == 'success' || needs.build-tiktok-organic.result == 'success') }}
+    if: ${{ !cancelled() && !failure() && (needs.build-gateway.result == 'success' || needs.build-warehouse.result == 'success' || needs.build-meta-ads.result == 'success' || needs.build-facebook.result == 'success' || needs.build-instagram.result == 'success' || needs.build-google-ads.result == 'success' || needs.build-ga4.result == 'success' || needs.build-gsc.result == 'success' || needs.build-shopify.result == 'success' || needs.build-powerbi.result == 'success' || needs.build-tiktok-organic.result == 'success' || needs.build-dhl.result == 'success') }}
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -54,3 +54,7 @@ services:
   powerbi_timeless_mcp:
     build: ./mcp/powerbi
     image: ghcr.io/choizapp/choiz-mcp-gateway/powerbi:dev
+
+  dhl_mcp:
+    build: ./mcp/dhl
+    image: ghcr.io/choizapp/choiz-mcp-gateway/dhl:dev

--- a/compose.yml
+++ b/compose.yml
@@ -39,6 +39,7 @@ services:
       UPSTREAM_POWERBI_CHOIZ: "http://powerbi_choiz_mcp:8080"
       UPSTREAM_POWERBI_TIMELESS: "http://powerbi_timeless_mcp:8080"
       UPSTREAM_TIKTOK_ORGANIC_CHOIZ: "http://tiktok_organic_choiz_mcp:8080"
+      UPSTREAM_DHL: "http://dhl_mcp:8080"
       # Remote MCPs proxied through the gateway (no internal container).
       # The route is only registered if the corresponding API key is set;
       # gateway/src/index.ts logs a skip-warning otherwise. See memory
@@ -74,6 +75,7 @@ services:
       - powerbi_choiz_mcp
       - powerbi_timeless_mcp
       - tiktok_organic_choiz_mcp
+      - dhl_mcp
     restart: unless-stopped
 
   warehouse_mcp:
@@ -336,4 +338,31 @@ services:
       TIKTOK_CLIENT_SECRET: ${TIKTOK_CHOIZ_CLIENT_SECRET:?set TIKTOK_CHOIZ_CLIENT_SECRET in .env}
       TIKTOK_REFRESH_TOKEN: ${TIKTOK_CHOIZ_REFRESH_TOKEN:?set TIKTOK_CHOIZ_REFRESH_TOKEN in .env}
       TIKTOK_BRAND: choiz
+    restart: unless-stopped
+
+  # DHL Express MCP — single tenant (one DHL Express account). Custom FastMCP
+  # server (mcp/dhl/entrypoint.py) wrapping the MyDHL API over HTTP Basic auth.
+  # Mirrors the tiktok-organic shape: requests + stateless_http, no SDK.
+  #
+  # WRITE-CAPABLE — unlike every other MCP here. create_shipment /
+  # create_return_shipment generate real labels and can bill the DHL account.
+  # Two guards: (1) the gateway auth chain is the only way in; (2) DHL_BASE_URL
+  # defaults to the MyDHL *test* base inside the entrypoint, so production
+  # bookings only happen when DHL_BASE_URL is explicitly set to the production
+  # base below. Leave DHL_BASE_URL unset (test) until create-shipment payloads
+  # are validated.
+  #
+  # Auth: DHL_API_KEY + DHL_API_SECRET (developer-portal app bound to the DHL
+  # Express account) → static Basic header, no token refresh.
+  dhl_mcp:
+    image: ghcr.io/choizapp/choiz-mcp-gateway/dhl:${IMAGE_TAG:-latest}
+    environment:
+      DHL_API_KEY: ${DHL_API_KEY:?set DHL_API_KEY in .env}
+      DHL_API_SECRET: ${DHL_API_SECRET:?set DHL_API_SECRET in .env}
+      # Optional. Unset = MyDHL test base (safe default). Set to
+      # https://express.api.dhl.com/mydhlapi for production.
+      DHL_BASE_URL: ${DHL_BASE_URL:-}
+      # Optional convenience default; the DHL account number normally travels
+      # in the shipment body's `accounts`, not as a header.
+      DHL_ACCOUNT_NUMBER: ${DHL_ACCOUNT_NUMBER:-}
     restart: unless-stopped

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -36,6 +36,11 @@ const upstreams: Record<string, string | undefined> = {
   // for the same reason as powerbi (avoids LLM picking the wrong tenant).
   // Choiz only at launch; Timeless slot pending Dev Portal app + tokens.
   "/mcp/tiktok-organic-choiz": process.env.UPSTREAM_TIKTOK_ORGANIC_CHOIZ,
+  // DHL Express MCP — single tenant. Tracking (read) + label/return generation
+  // (WRITE) via the MyDHL API. The only write-capable MCP in the gateway; the
+  // /mcp auth guard above is its sole access barrier. Server-side HTTP Basic
+  // auth to DHL; end users only see Google Workspace login.
+  "/mcp/dhl":                  process.env.UPSTREAM_DHL,
 };
 
 // --- Remote MCPs proxied through the gateway (no internal container) ---

--- a/mcp/dhl/Dockerfile
+++ b/mcp/dhl/Dockerfile
@@ -1,0 +1,36 @@
+# DHL Express MCP — custom server, no upstream package to wrap.
+#
+# Talks to the MyDHL API (DHL Express REST, express.api.dhl.com) over HTTP
+# Basic auth. End users authenticate to claude.ai with Google Workspace; they
+# never see a DHL login.
+#
+# Single-tenant (one DHL Express account). Mirrors the tiktok-organic shape:
+# FastMCP + requests, stateless_http=True, no SDK — the surface we use is a
+# handful of REST endpoints.
+#
+# WRITE-CAPABLE: create_shipment / create_return_shipment generate real labels.
+# DHL_BASE_URL defaults to the MyDHL test environment inside entrypoint.py;
+# production requires deliberately overriding it in the EC2 .env.
+
+FROM python:3.12-slim
+
+# ca-certificates: HTTPS to express.api.dhl.com.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Pin mcp to 1.25.0 to match the rest of the stack (warehouse / facebook /
+# instagram / ga4 / powerbi / tiktok-organic). requests for the DHL HTTP calls.
+RUN pip install --no-cache-dir \
+    'mcp==1.25.0' \
+    'requests>=2.31,<3'
+
+ENV PYTHONUNBUFFERED=1
+
+COPY entrypoint.py /opt/entrypoint.py
+
+EXPOSE 8080
+
+ENTRYPOINT ["python", "/opt/entrypoint.py"]

--- a/mcp/dhl/entrypoint.py
+++ b/mcp/dhl/entrypoint.py
@@ -1,0 +1,301 @@
+"""DHL Express MCP — tracking + label/return generation via MyDHL API.
+
+Wraps the MyDHL API (DHL Express REST, https://developer.dhl.com/api-reference/mydhl-api-dhl-express).
+Single-tenant: one DHL Express account, credentials in env. End users
+authenticate to claude.ai with Google Workspace and reach this through the
+gateway; they never see a DHL login.
+
+UNLIKE every other MCP in this gateway, this one performs WRITES (creating
+shipments / return shipments produces real labels and can trigger billing on
+the DHL account). Two structural guards keep that safe:
+  1. The gateway auth chain (x-worker-shared-secret + Workspace email) is the
+     only path in — same guard as the read-only MCPs.
+  2. DHL_BASE_URL defaults to the MyDHL **test** environment
+     (.../mydhlapi/test). Production label creation only happens once someone
+     deliberately sets DHL_BASE_URL to the production base in the EC2 .env.
+     Keep it on test until the create-shipment payloads are validated.
+
+Auth model:
+  MyDHL API uses HTTP Basic auth: Authorization: Basic base64(API_KEY:API_SECRET).
+  The API key/secret pair comes from the DHL developer portal app bound to the
+  DHL Express account. No token refresh — the Basic header is static.
+
+Tool surface:
+  read:
+    - track_shipment(tracking_number)        : GET /shipments/{n}/tracking
+    - validate_address(country_code, postal_code, ...) : GET /address-validate
+    - get_rates(payload)                     : POST /rates (quote only, no booking)
+  write:
+    - create_shipment(payload)               : POST /shipments  -> tracking + label
+    - create_return_shipment(payload)        : POST /shipments (return product) -> tracking + label
+
+Payload-ceiling discipline (see project_claudeai_payload_ceiling + ADDING_AN_MCP):
+  A MyDHL label PDF returned as base64 is tens of KB — far past claude.ai's
+  ~2-3 KB tool-result ceiling. _trim_documents() strips the base64 `content`
+  by default, returning tracking number + document metadata (typeCode, format,
+  base64 length) instead. Pass include_label_content=True to force the raw
+  base64 back (works via curl/direct API; will likely fail through claude.ai).
+  Prefer requesting URL-referenced labels in your payload's
+  outputImageProperties so the wrapper returns a short link instead.
+
+The MyDHL shipment body is large and account-specific (~hundreds of fields:
+shipper/receiver accounts, productCode, packages, customs, value-added
+services). create_shipment / create_return_shipment therefore take the body as
+a passthrough `payload` dict shaped per the MyDHL API spec, rather than
+re-modeling every field here. The wrapper only injects auth + required headers
+and trims the response.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import uuid
+from typing import Any
+
+import requests
+from mcp.server.fastmcp import FastMCP
+
+logger = logging.getLogger("dhl_mcp")
+logging.basicConfig(
+    level=os.environ.get("LOG_LEVEL", "INFO"),
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+
+# --- Config from env ------------------------------------------------------
+
+API_KEY = os.environ["DHL_API_KEY"]
+API_SECRET = os.environ["DHL_API_SECRET"]
+# Default to the MyDHL TEST base. Flip to production
+# (https://express.api.dhl.com/mydhlapi) deliberately in the EC2 .env once
+# create-shipment payloads are validated — see the module docstring.
+BASE_URL = os.environ.get(
+    "DHL_BASE_URL", "https://express.api.dhl.com/mydhlapi/test"
+).rstrip("/")
+# Optional: DHL Express account number. Most MyDHL calls carry the account in
+# the request body (`accounts`), so this is only used as a convenience default
+# the caller can reference; it is NOT auto-injected into payloads.
+ACCOUNT_NUMBER = os.environ.get("DHL_ACCOUNT_NUMBER", "")
+
+_AUTH_HEADER = "Basic " + base64.b64encode(
+    f"{API_KEY}:{API_SECRET}".encode()
+).decode()
+
+# Truncate any base64 document content longer than this before returning it
+# to the model, to stay under claude.ai's payload ceiling.
+_MAX_DOC_CONTENT_CHARS = 256
+
+
+# --- HTTP helper ----------------------------------------------------------
+
+
+def _request(
+    method: str,
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+    body: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Authenticated MyDHL API call. Raises RuntimeError on non-2xx so the LLM
+    gets actionable feedback (DHL error bodies carry `detail` + `additionalDetails`).
+    """
+    url = f"{BASE_URL}{path}"
+    headers = {
+        "Authorization": _AUTH_HEADER,
+        "Accept": "application/json",
+    }
+    if method == "POST":
+        headers["Content-Type"] = "application/json"
+        # MyDHL requires a unique Message-Reference (28-36 chars) on write calls.
+        headers["Message-Reference"] = uuid.uuid4().hex  # 32 hex chars
+    resp = requests.request(
+        method, url, headers=headers, params=params, json=body, timeout=45
+    )
+    try:
+        data = resp.json()
+    except ValueError:
+        data = {"raw": resp.text}
+
+    # 2xx (including 207 multistatus on multi-piece shipments) -> success.
+    if 200 <= resp.status_code < 300:
+        return data
+
+    detail = data.get("detail") or data.get("title") or data.get("message")
+    extra = data.get("additionalDetails")
+    raise RuntimeError(
+        f"DHL API error on {method} {path} (HTTP {resp.status_code}): "
+        f"{detail}" + (f" — {extra}" if extra else "")
+    )
+
+
+def _trim_documents(data: dict[str, Any], *, include_content: bool) -> dict[str, Any]:
+    """Strip heavy base64 label content out of a shipment response.
+
+    MyDHL returns created labels/invoices under `documents[].content` as base64.
+    Left inline these blow past claude.ai's payload ceiling. Unless the caller
+    opts in with include_content=True, replace each `content` with a small
+    metadata stub. Mutates a shallow copy and returns it.
+    """
+    if not isinstance(data, dict):
+        return data
+    docs = data.get("documents")
+    if isinstance(docs, list):
+        trimmed = []
+        for doc in docs:
+            if not isinstance(doc, dict):
+                trimmed.append(doc)
+                continue
+            d = dict(doc)
+            content = d.get("content")
+            if (
+                isinstance(content, str)
+                and len(content) > _MAX_DOC_CONTENT_CHARS
+                and not include_content
+            ):
+                d["content"] = {
+                    "omitted": True,
+                    "base64_length": len(content),
+                    "note": (
+                        "Label base64 omitted to stay under claude.ai's payload "
+                        "ceiling. Retrieve via direct API with include_label_content=True, "
+                        "or request URL-referenced output in outputImageProperties."
+                    ),
+                }
+            trimmed.append(d)
+        data = dict(data)
+        data["documents"] = trimmed
+    return data
+
+
+# --- MCP server -----------------------------------------------------------
+
+# host="0.0.0.0" so the gateway reaches us across the docker bridge.
+# streamable_http_path="/" so the gateway can strip /mcp/dhl and forward to "/".
+# stateless_http=True: ephemeral sessions, sidesteps stale-session-after-redeploy.
+mcp = FastMCP(
+    name="dhl",
+    host="0.0.0.0",
+    port=8080,
+    streamable_http_path="/",
+    stateless_http=True,
+)
+
+
+@mcp.tool()
+def track_shipment(tracking_number: str) -> dict[str, Any]:
+    """Track a DHL Express shipment by its waybill / tracking number.
+
+    Calls GET /shipments/{tracking_number}/tracking. Returns the shipment's
+    current status plus the event history (timestamp, location, status text).
+    Read-only.
+    """
+    data = _request("GET", f"/shipments/{tracking_number}/tracking")
+    # Response shape: {"shipments": [{"shipmentTrackingNumber", "status",
+    #   "estimatedDeliveryDate", "events": [...], "origin", "destination"}]}
+    return data
+
+
+@mcp.tool()
+def validate_address(
+    country_code: str,
+    postal_code: str = "",
+    city_name: str = "",
+    address_type: str = "delivery",
+) -> dict[str, Any]:
+    """Validate / resolve an address against DHL Express coverage.
+
+    Calls GET /address-validate. Useful before creating a shipment to confirm
+    the destination is serviceable and to get the matched city/postal code.
+    `address_type` is "delivery" or "pickup". Read-only.
+    """
+    params: dict[str, Any] = {"type": address_type, "countryCode": country_code}
+    if postal_code:
+        params["postalCode"] = postal_code
+    if city_name:
+        params["cityName"] = city_name
+    return _request("GET", "/address-validate", params=params)
+
+
+@mcp.tool()
+def get_rates(payload: dict[str, Any]) -> dict[str, Any]:
+    """Get a rate quote for a prospective shipment (no booking, no label).
+
+    Calls POST /rates with a MyDHL-API-shaped rate request body (customerDetails
+    with shipper/receiver addresses, plannedShippingDateAndTime, accounts,
+    packages). Returns available products with prices and transit times.
+    Read-only — does NOT create a shipment.
+
+    See the MyDHL API reference ("Get Rates") for the exact body schema.
+    """
+    return _request("POST", "/rates", body=payload)
+
+
+@mcp.tool()
+def create_shipment(
+    payload: dict[str, Any],
+    include_label_content: bool = False,
+) -> dict[str, Any]:
+    """Create a DHL Express shipment and generate its label. WRITE OPERATION.
+
+    Calls POST /shipments with a full MyDHL-API shipment body (passthrough).
+    On success returns the assigned tracking number(s) and document metadata.
+
+    IMPORTANT — this books a real shipment on the DHL account and may incur
+    charges. It hits whatever DHL_BASE_URL points at; that defaults to the
+    MyDHL TEST environment. Production only when DHL_BASE_URL is set to the
+    production base in the EC2 .env.
+
+    The `payload` must follow the MyDHL API "Create Shipment" schema, e.g.:
+      {
+        "plannedShippingDateAndTime": "2026-06-10T13:00:00 GMT+00:00",
+        "productCode": "P",                # DHL Express product (e.g. P = Worldwide)
+        "accounts": [{"typeCode": "shipper", "number": "<DHL_ACCOUNT_NUMBER>"}],
+        "customerDetails": {"shipperDetails": {...}, "receiverDetails": {...}},
+        "content": {"packages": [...], "isCustomsDeclarable": false, ...},
+        "outputImageProperties": {...}     # request URL output here to avoid base64
+      }
+
+    Label handling: MyDHL returns labels under documents[].content as base64.
+    That is stripped by default (payload ceiling). Set include_label_content=True
+    to force the raw base64 back — works via direct API/curl but will likely
+    exceed claude.ai's tool-result ceiling. Prefer requesting URL-referenced
+    documents in outputImageProperties.
+    """
+    data = _request("POST", "/shipments", body=payload)
+    return _trim_documents(data, include_content=include_label_content)
+
+
+@mcp.tool()
+def create_return_shipment(
+    payload: dict[str, Any],
+    include_label_content: bool = False,
+) -> dict[str, Any]:
+    """Create a DHL Express RETURN shipment + return label. WRITE OPERATION.
+
+    Same endpoint as create_shipment (POST /shipments) — a return is modeled in
+    the body by using your account's return product code and swapping shipper /
+    receiver so the parcel routes back to you. Configure the return per your DHL
+    Express account (paperless return vs printed return label) in `payload`.
+
+    Same billing + TEST/production caveats and same base64 label-stripping
+    behaviour as create_shipment. See the MyDHL API reference for the return
+    body schema.
+    """
+    data = _request("POST", "/shipments", body=payload)
+    return _trim_documents(data, include_content=include_label_content)
+
+
+def main() -> None:
+    env = "TEST" if "/test" in BASE_URL else "PRODUCTION"
+    logger.info("dhl mcp starting — base=%s (%s)", BASE_URL, env)
+    if env == "PRODUCTION":
+        logger.warning(
+            "DHL_BASE_URL points at PRODUCTION — create_shipment / "
+            "create_return_shipment will book real shipments and may incur charges."
+        )
+    mcp.run(transport="streamable-http")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Qué

Agrega el MCP **DHL Express** al gateway, expuesto en `/mcp/dhl/`. Wrappea la **MyDHL API** (DHL Express REST, `express.api.dhl.com/mydhlapi`) sobre HTTP Basic auth, single-tenant. Mismo patrón que `tiktok-organic`: FastMCP custom + `requests`, `stateless_http=True`, sin SDK.

No existe un MCP oficial de DHL de runtime (el "DHL API Assistant MCP" es solo sandbox + asistente de integración), por eso se wrappea la REST API directamente.

## Tools

| Tool | Tipo |
|---|---|
| `track_shipment` | read |
| `validate_address` | read |
| `get_rates` | read (quote, no booking) |
| `create_shipment` | **write** — genera label |
| `create_return_shipment` | **write** — genera return label |

## ⚠️ Primer MCP write-capable del gateway

Todos los demás MCPs son read-only. Dos guards:

1. **`DHL_BASE_URL` default = entorno TEST** de MyDHL dentro del entrypoint. Producción solo si se setea explícitamente `DHL_BASE_URL=https://express.api.dhl.com/mydhlapi` en el `.env` de la EC2.
2. La cadena de auth del gateway (`x-worker-shared-secret` + email Workspace) es la única barrera de acceso, igual que los read-only.

## Payload ceiling

Los labels de MyDHL vuelven como PDF en base64 (decenas de KB, por encima del techo ~2-3 KB de claude.ai). `_trim_documents()` recorta el `content` base64 por defecto; se puede pedir el blob con `include_label_content=True` o (mejor) solicitar salida tipo URL en `outputImageProperties`.

## Wiring

- `mcp/dhl/{entrypoint.py,Dockerfile}`
- `compose.yml`: service `dhl_mcp` + `UPSTREAM_DHL` + `depends_on`
- `compose.dev.yml`: build local
- `gateway/src/index.ts`: ruta `/mcp/dhl`
- `.env.example`: `DHL_API_KEY` / `DHL_API_SECRET` / `DHL_BASE_URL` / `DHL_ACCOUNT_NUMBER`
- CI: filtro + job `build-dhl` + wiring del deploy

## Antes de mergear

`DHL_API_KEY` + `DHL_API_SECRET` (creds **test**) ya están cargados en el `.env` de la EC2 vía SSM. `compose.yml` usa `:?` fail-fast en ambos, así que tienen que estar seteados antes del merge o el `docker compose up -d` rompe todo el stack.

## Después de mergear

1. CI buildea `dhl` + deploya.
2. Smoke test `/mcp/dhl/` desde la EC2.
3. Agregar connector en claude.ai (`https://mcp.choiz.com.mx/mcp/dhl/`).
4. Validar el schema del body de `create_shipment`/`create_return_shipment` contra la cuenta DHL Express antes de cualquier cutover a producción.

🤖 Generated with [Claude Code](https://claude.com/claude-code)