### PR TITLE
fix(dhl): treat empty DHL_BASE_URL as unset so test default applies

### DIFF
--- a/mcp/dhl/entrypoint.py
+++ b/mcp/dhl/entrypoint.py
@@ -70,8 +70,11 @@ API_SECRET = os.environ["DHL_API_SECRET"]
 # Default to the MyDHL TEST base. Flip to production
 # (https://express.api.dhl.com/mydhlapi) deliberately in the EC2 .env once
 # create-shipment payloads are validated — see the module docstring.
-BASE_URL = os.environ.get(
-    "DHL_BASE_URL", "https://express.api.dhl.com/mydhlapi/test"
+# NB: compose passes DHL_BASE_URL=${DHL_BASE_URL:-}, i.e. the var is present
+# but EMPTY when unset. os.environ.get(..., default) does NOT fall back on an
+# empty string (the key exists), so use `or` to treat "" as "use the default".
+BASE_URL = (
+    os.environ.get("DHL_BASE_URL") or "https://express.api.dhl.com/mydhlapi/test"
 ).rstrip("/")
 # Optional: DHL Express account number. Most MyDHL calls carry the account in
 # the request body (`accounts`), so this is only used as a convenience default


### PR DESCRIPTION
Follow-up to #35, caught by the post-deploy smoke test.

`compose.yml` passes `DHL_BASE_URL: ${DHL_BASE_URL:-}` → the var is **present but empty** when unset. `os.environ.get("DHL_BASE_URL", default)` returns `""` (not the default) because the key exists, so `BASE_URL` became `""` and startup logged `base= (PRODUCTION)`.

Impact: the MCP `initialize` handshake still worked (doesn't touch DHL), so the smoke test returned 200 — but any real tool call (`track_shipment`, `create_shipment`, ...) would POST to a hostless path, and the test/prod safety guard was inverted.

Fix: `os.environ.get("DHL_BASE_URL") or "<test-base>"` so an empty value falls back to the MyDHL **test** base. One line, only `mcp/dhl/entrypoint.py` (rebuilds just the `dhl` image).

After merge: confirm logs show `base=https://express.api.dhl.com/mydhlapi/test (TEST)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)