### PR TITLE
fix(gateway): correct /dl/dhl path rewrite (Express strips mount prefix)

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -185,8 +185,11 @@ if (dhlDownloadTarget) {
     createProxyMiddleware({
       target: dhlDownloadTarget,
       changeOrigin: true,
-      // /dl/dhl/<token> -> /download/<token> on the MCP container.
-      pathRewrite: { "^/dl/dhl": "/download" },
+      // Express strips the "/dl/dhl" mount prefix before the proxy runs, so
+      // pathRewrite sees the already-stripped "/<token>". Rewrite the leading
+      // slash to "/download/" so the MCP receives /download/<token>.
+      // (A "^/dl/dhl" rewrite would be a no-op — the prefix is already gone.)
+      pathRewrite: { "^/": "/download/" },
       selfHandleResponse: false,
       on: {
         proxyReq: (proxyReq) => {


### PR DESCRIPTION
Follow-up to #38. The label download link returned 404: `app.use("/dl/dhl", ...)` makes Express strip the prefix, so http-proxy-middleware's `pathRewrite` saw `/<token>` and the `^/dl/dhl` rule was a no-op → the MCP got `/<token>` → Starlette default 404.

Verified live: MCP `/download/<tok>` → our handler's 404; MCP `/<tok>` → Starlette "Not Found"; gateway `/dl/dhl/<tok>` → "Not Found". Fix: rewrite `^/` → `/download/`. Only `gateway/src/index.ts` (rebuilds just the gateway image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)