### PR TITLE
fix(dhl): auto-inject required pickup default

### DIFF
--- a/mcp/dhl/entrypoint.py
+++ b/mcp/dhl/entrypoint.py
@@ -397,11 +397,14 @@ def _apply_shipment_defaults(payload: dict[str, Any]) -> dict[str, Any]:
       "Hand to Courier" page), so the guide matches the manual MyDHL+ output.
     - accounts: inject the shipper account from DHL_ACCOUNT_NUMBER if absent, so
       "Payer Details / Freight A/C" populates.
+    - pickup: MyDHL REQUIRES this key (422 "required key [pickup] not found"
+      otherwise). Default to no scheduled pickup (drop-off / OCURRE flow).
     """
     if not isinstance(payload, dict):
         return payload
     p = dict(payload)
     p.setdefault("outputImageProperties", _DEFAULT_OUTPUT_IMAGE_PROPERTIES)
+    p.setdefault("pickup", {"isRequested": False})
     if ACCOUNT_NUMBER and not p.get("accounts"):
         p["accounts"] = [{"typeCode": "shipper", "number": ACCOUNT_NUMBER}]
     return p


### PR DESCRIPTION
Follow-up to #40. MyDHL requires `pickup` in the shipment body (422 otherwise); the model omitted it on a minimal payload. Auto-inject `pickup: {isRequested:false}` in `_apply_shipment_defaults` (drop-off/OCURRE default; operator can override to schedule a courier).

Validated in test: minimal payload → 2-page label (label + waybillDoc) via download_url. Only `mcp/dhl/entrypoint.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)