### PR TITLE
feat(sheets): Google Sheets MCP (read + gated write)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -220,3 +220,30 @@ DHL_ALLOW_CREATE=
 # blank to use the default. LABEL_TTL_MINUTES controls link expiry.
 LABEL_DOWNLOAD_BASE_URL=
 LABEL_TTL_MINUTES=
+
+# --- Google Sheets MCP (single tenant; READ + WRITE-capable) ---
+#
+# xing5/mcp-google-sheets (FastMCP), served in-process over Streamable HTTP.
+# Single slug /mcp/sheets — Sheets are not brand-scoped; the model addresses
+# each spreadsheet by ID and access is whatever is shared with the SA.
+#
+# Auth: a DEDICATED `sheets-editor` service account — do NOT reuse the
+# read-only ga4-mcp-reader. Requirements:
+#   1. A GCP project with the Google Sheets API + Google Drive API enabled.
+#   2. A service account; download its JSON key.
+#   3. Share EACH spreadsheet the bot should touch with the SA's
+#      client_email (Editor for writes, Viewer for read-only). The SA sees
+#      nothing in Drive that has not been explicitly shared with it.
+#
+# The package's env name is CREDENTIALS_CONFIG (base64 of the SA JSON);
+# compose.yml aliases this var into it. Single-line base64:
+#   Linux/macOS:  base64 -w0 /path/to/sheets-editor.json
+#   PowerShell:   [Convert]::ToBase64String([IO.File]::ReadAllBytes("path\to\sheets-editor.json"))
+SHEETS_SERVICE_ACCOUNT_JSON_B64=
+
+# Write kill-switch — mirrors DHL_ALLOW_CREATE. Default OFF (false): only the
+# read-only tools (get_/list_/search_) are registered. Set "true" + restart to
+# expose the write tools (update_cells, batch_update, add_rows/columns,
+# create_spreadsheet, create_sheet, copy_sheet, rename_sheet,
+# share_spreadsheet, add_chart). Flip back + restart to instantly stop writes.
+SHEETS_ALLOW_WRITE=

--- a/.github/workflows/deploy-gateway.yml
+++ b/.github/workflows/deploy-gateway.yml
@@ -55,6 +55,7 @@ jobs:
       powerbi: ${{ steps.filter.outputs.powerbi }}
       tiktok_organic: ${{ steps.filter.outputs.tiktok_organic }}
       dhl: ${{ steps.filter.outputs.dhl }}
+      sheets: ${{ steps.filter.outputs.sheets }}
       compose: ${{ steps.filter.outputs.compose }}
     steps:
       - uses: actions/checkout@v4
@@ -86,6 +87,8 @@ jobs:
               - 'mcp/tiktok-organic/**'
             dhl:
               - 'mcp/dhl/**'
+            sheets:
+              - 'mcp/sheets/**'
             compose:
               - 'compose.yml'
 
@@ -415,13 +418,40 @@ jobs:
           cache-from: type=gha,scope=dhl
           cache-to: type=gha,mode=max,scope=dhl
 
+  build-sheets:
+    name: Build sheets image
+    needs: changes
+    if: needs.changes.outputs.sheets == 'true' || needs.changes.outputs.compose == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./mcp/sheets
+          push: true
+          platforms: linux/arm64
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/sheets:latest
+            ${{ env.IMAGE_PREFIX }}/sheets:${{ github.sha }}
+          cache-from: type=gha,scope=sheets
+          cache-to: type=gha,mode=max,scope=sheets
+
   deploy:
     name: Deploy on EC2 via SSM
-    needs: [build-gateway, build-warehouse, build-meta-ads, build-facebook, build-instagram, build-google-ads, build-ga4, build-gsc, build-shopify, build-powerbi, build-tiktok-organic, build-dhl]
+    needs: [build-gateway, build-warehouse, build-meta-ads, build-facebook, build-instagram, build-google-ads, build-ga4, build-gsc, build-shopify, build-powerbi, build-tiktok-organic, build-dhl, build-sheets]
     # Run only if at least one build succeeded. If all builds were skipped
     # (because nothing relevant changed, e.g. workflow-only edit), do not
     # touch the EC2 — there's nothing to deploy.
-    if: ${{ !cancelled() && !failure() && (needs.build-gateway.result == 'success' || needs.build-warehouse.result == 'success' || needs.build-meta-ads.result == 'success' || needs.build-facebook.result == 'success' || needs.build-instagram.result == 'success' || needs.build-google-ads.result == 'success' || needs.build-ga4.result == 'success' || needs.build-gsc.result == 'success' || needs.build-shopify.result == 'success' || needs.build-powerbi.result == 'success' || needs.build-tiktok-organic.result == 'success' || needs.build-dhl.result == 'success') }}
+    if: ${{ !cancelled() && !failure() && (needs.build-gateway.result == 'success' || needs.build-warehouse.result == 'success' || needs.build-meta-ads.result == 'success' || needs.build-facebook.result == 'success' || needs.build-instagram.result == 'success' || needs.build-google-ads.result == 'success' || needs.build-ga4.result == 'success' || needs.build-gsc.result == 'success' || needs.build-shopify.result == 'success' || needs.build-powerbi.result == 'success' || needs.build-tiktok-organic.result == 'success' || needs.build-dhl.result == 'success' || needs.build-sheets.result == 'success') }}
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -58,3 +58,7 @@ services:
   dhl_mcp:
     build: ./mcp/dhl
     image: ghcr.io/choizapp/choiz-mcp-gateway/dhl:dev
+
+  sheets_mcp:
+    build: ./mcp/sheets
+    image: ghcr.io/choizapp/choiz-mcp-gateway/sheets:dev

--- a/compose.yml
+++ b/compose.yml
@@ -40,6 +40,7 @@ services:
       UPSTREAM_POWERBI_TIMELESS: "http://powerbi_timeless_mcp:8080"
       UPSTREAM_TIKTOK_ORGANIC_CHOIZ: "http://tiktok_organic_choiz_mcp:8080"
       UPSTREAM_DHL: "http://dhl_mcp:8080"
+      UPSTREAM_SHEETS: "http://sheets_mcp:8080"
       # Remote MCPs proxied through the gateway (no internal container).
       # The route is only registered if the corresponding API key is set;
       # gateway/src/index.ts logs a skip-warning otherwise. See memory
@@ -76,6 +77,7 @@ services:
       - powerbi_timeless_mcp
       - tiktok_organic_choiz_mcp
       - dhl_mcp
+      - sheets_mcp
     restart: unless-stopped
 
   warehouse_mcp:
@@ -375,4 +377,42 @@ services:
       # create_return_shipment refuse unless this is truthy. Set to "true" in
       # .env to let operators emit guides; flip back + restart to stop instantly.
       DHL_ALLOW_CREATE: ${DHL_ALLOW_CREATE:-false}
+    restart: unless-stopped
+
+  # Google Sheets MCP — xing5/mcp-google-sheets (FastMCP), served in-process
+  # over Streamable HTTP by mcp/sheets/entrypoint.py. Same single-process
+  # shape as ga4 / google-ads; no supergateway.
+  #
+  # Single tenant, single slug (/mcp/sheets). Sheets are not brand-scoped, so
+  # there is no choiz/timeless split — the model addresses each spreadsheet by
+  # its ID, and access is whatever is shared with the SA.
+  #
+  # Auth: a DEDICATED `sheets-editor` service account (NOT the read-only
+  # ga4-mcp-reader). The package reads CREDENTIALS_CONFIG as base64 SA JSON
+  # and builds credentials in-process (no /tmp file). Each spreadsheet to be
+  # touched must be shared with the SA's client_email (Editor for writes).
+  #
+  # Write kill-switch — mirrors dhl's DHL_ALLOW_CREATE. Default OFF: the
+  # entrypoint pins ENABLED_TOOLS to the read-only subset unless
+  # SHEETS_ALLOW_WRITE is truthy, in which case all 20 tools (incl.
+  # update_cells / batch_update / create_spreadsheet / share_spreadsheet)
+  # are exposed. Flip to "true" in .env + restart to enable writes; flip
+  # back + restart to stop instantly.
+  #
+  # mem_limit is a TIGHT 256m (not ga4's loose 1500m placeholder): measured
+  # idle RSS is ~74 MB (REST-only stack, no grpcio, unlike ga4/google-ads).
+  # On a 2 GB t4g.small running ~18 containers a per-container cap smaller
+  # than total RAM is the whole point — if this MCP ever leaks, Docker
+  # OOM-kills only this container (restart: unless-stopped) instead of the
+  # kernel OOM-killer evicting a random neighbor. Raise only if a large
+  # get_sheet_data response is observed pushing past the cap.
+  sheets_mcp:
+    image: ghcr.io/choizapp/choiz-mcp-gateway/sheets:${IMAGE_TAG:-latest}
+    environment:
+      # The package's env name is CREDENTIALS_CONFIG; we keep the repo's
+      # *_SERVICE_ACCOUNT_JSON_B64 convention on the .env side and alias here.
+      CREDENTIALS_CONFIG: ${SHEETS_SERVICE_ACCOUNT_JSON_B64:?set SHEETS_SERVICE_ACCOUNT_JSON_B64 in .env}
+      SHEETS_ALLOW_WRITE: ${SHEETS_ALLOW_WRITE:-false}
+    mem_limit: 256m
+    pids_limit: 100
     restart: unless-stopped

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -41,6 +41,14 @@ const upstreams: Record<string, string | undefined> = {
   // /mcp auth guard above is its sole access barrier. Server-side HTTP Basic
   // auth to DHL; end users only see Google Workspace login.
   "/mcp/dhl":                  process.env.UPSTREAM_DHL,
+  // Google Sheets MCP — read + WRITE. Single slug, single container:
+  // Sheets are not brand-scoped the way GA4 properties / Power BI datasets
+  // are, so there is no choiz/timeless split. Access is bounded by which
+  // spreadsheets are shared with the sheets-editor service account, plus
+  // the /mcp auth guard above. Write-capable like dhl (see note above);
+  // unlike dhl the blast radius is "any Sheet shared with the SA", so keep
+  // the SA's sharing surface tight.
+  "/mcp/sheets":               process.env.UPSTREAM_SHEETS,
 };
 
 // --- Remote MCPs proxied through the gateway (no internal container) ---

--- a/mcp/sheets/Dockerfile
+++ b/mcp/sheets/Dockerfile
@@ -1,0 +1,67 @@
+# Google Sheets MCP — read + write to Google Sheets / Drive
+# (get_sheet_data, update_cells, batch_update_cells, add_rows, add_columns,
+# create_spreadsheet, create_sheet, copy_sheet, rename_sheet,
+# share_spreadsheet, add_chart, list_spreadsheets, search_spreadsheets, ...).
+#
+# Source: https://github.com/xing5/mcp-google-sheets — public PyPI package
+# `mcp-google-sheets`, no Choiz fork. Built on FastMCP
+# (mcp.server.fastmcp.FastMCP), same server framework as the official
+# ga4 / google-ads MCPs we already run in-process.
+#
+# Transport: FastMCP speaks Streamable HTTP natively. We do NOT use
+# supergateway (dropped stack-wide on 2026-05-07; --stateless leaks,
+# --stateful trips supergateway #126 with claude.ai). entrypoint.py imports
+# the package's module-level `mcp` FastMCP instance, forces its mount path
+# to "/" (FastMCP defaults to "/mcp", but the gateway strips the
+# /mcp/<name> prefix and forwards to upstream at "/"), and serves it on
+# 0.0.0.0:8080. Same in-process shape as mcp/ga4/.
+#
+# Auth: dedicated `sheets-editor` service account (NOT the read-only
+# ga4-mcp-reader). The package reads CREDENTIALS_CONFIG — a single-line
+# base64 of the SA JSON — and builds service_account.Credentials directly,
+# so no /tmp file materialization is needed (cleaner than ga4/gsc). The
+# SA must have the Sheets + Drive APIs enabled and EACH target spreadsheet
+# shared with its client_email as Editor. See compose.yml + .env.example.
+#
+# Write surface: this is the first read+write MCP in the gateway (warehouse
+# is read-only, ga4/gsc are readers). Scope is bounded by what is shared
+# with the SA, not by API scope alone.
+#
+# Pin to a commit of the upstream main branch for reproducibility. Bump
+# SHEETS_MCP_VERSION deliberately after testing a newer release.
+
+FROM python:3.12-slim
+
+# Pin the published package version (not a git SHA — this one ships clean
+# wheels on PyPI, unlike ga4/google-ads which we install from git).
+# 0.6.3 = current release: 20 tools and native ENABLED_TOOLS filtering
+# (verified — 0.5.x had only 15 tools and ignored ENABLED_TOOLS, which
+# would have silently defeated the write kill-switch).
+ARG SHEETS_MCP_VERSION=0.6.3
+
+# ca-certificates: HTTPS to sheets.googleapis.com + www.googleapis.com.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir \
+    "mcp-google-sheets==${SHEETS_MCP_VERSION}" \
+    "uvicorn[standard]"
+
+# Flush stdout immediately so init logs land in `docker logs` without delay.
+ENV PYTHONUNBUFFERED=1
+
+# The package resolves its bind host/port from HOST/PORT at import time.
+# Pin them here so the FastMCP instance binds where the gateway expects.
+# FASTMCP_STREAMABLE_HTTP_PATH is the env fallback for the mount-path
+# override the entrypoint also sets programmatically (FastMCP reads
+# settings from the FASTMCP_ env prefix). The gateway forwards to "/".
+ENV HOST=0.0.0.0 \
+    PORT=8080 \
+    FASTMCP_STREAMABLE_HTTP_PATH=/
+
+COPY entrypoint.py /opt/entrypoint.py
+
+EXPOSE 8080
+
+ENTRYPOINT ["python", "/opt/entrypoint.py"]

--- a/mcp/sheets/entrypoint.py
+++ b/mcp/sheets/entrypoint.py
@@ -1,0 +1,161 @@
+"""Google Sheets MCP entrypoint — xing5/mcp-google-sheets served over
+Streamable HTTP in-process, no supergateway.
+
+The upstream package (`mcp_google_sheets.server`) defines a module-level
+FastMCP instance ``mcp`` and, in its own ``main()``, simply calls
+``mcp.run(transport=<--transport arg>)`` defaulting to stdio. We don't use
+that CLI path because:
+
+  1. We need Streamable HTTP, not stdio/SSE.
+  2. FastMCP's Streamable HTTP app mounts at ``settings.streamable_http_path``
+     which defaults to "/mcp". The gateway strips the ``/mcp/<name>`` prefix
+     and forwards to the upstream at "/", so we must move the mount to "/"
+     or every call 404s (same lesson as supergateway's --streamableHttpPath).
+
+So we import the ready-built ``mcp`` instance, override the mount path to
+"/", and run it with the streamable-http transport. Importing the module is
+enough to register all @mcp.tool decorators (the package wires them at import
+time) and the ``spreadsheet_lifespan`` context manager that performs Google
+auth from CREDENTIALS_CONFIG. No extra init call is required.
+
+Auth: the package reads ``CREDENTIALS_CONFIG`` (base64 of the SA JSON) and
+builds ``service_account.Credentials.from_service_account_info(...)`` itself,
+so we do not materialize a file. compose.yml passes
+``SHEETS_SERVICE_ACCOUNT_JSON_B64`` into the container as ``CREDENTIALS_CONFIG``.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+
+# Tool classification for mcp-google-sheets 0.6.3 (verified against the
+# installed package's tool registry — 20 tools total). READ_ONLY are the
+# get_/list_/search_/find_ tools that never mutate. WRITE_TOOLS mutate cell
+# values, structure, or sharing.
+READ_ONLY_TOOLS = (
+    "get_sheet_data",
+    "get_sheet_formulas",
+    "get_multiple_sheet_data",
+    "get_multiple_spreadsheet_summary",
+    "list_spreadsheets",
+    "list_sheets",
+    "list_folders",
+    "search_spreadsheets",
+    "find_in_spreadsheet",
+)
+WRITE_TOOLS = (
+    "create_spreadsheet",
+    "create_sheet",
+    "update_cells",
+    "batch_update_cells",
+    "batch_update",
+    "add_rows",
+    "add_columns",
+    "copy_sheet",
+    "rename_sheet",
+    "share_spreadsheet",
+    "add_chart",
+)
+
+
+def _truthy(v: str | None) -> bool:
+    return (v or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _writes_allowed() -> bool:
+    return _truthy(os.environ.get("SHEETS_ALLOW_WRITE"))
+
+
+def _apply_write_gate() -> None:
+    """Optimization (pre-import): pin ENABLED_TOOLS to the read-only subset so
+    the package never even registers write tools. The package reads
+    ENABLED_TOOLS at import time. This is best-effort — correctness is
+    guaranteed by _enforce_write_gate() after import, not here — because
+    0.5.x silently ignored ENABLED_TOOLS. Skips if writes are allowed or an
+    operator set ENABLED_TOOLS explicitly.
+    """
+    log = logging.getLogger(__name__)
+    if _writes_allowed() or os.environ.get("ENABLED_TOOLS"):
+        return
+    os.environ["ENABLED_TOOLS"] = ",".join(READ_ONLY_TOOLS)
+    log.info("SHEETS_ALLOW_WRITE off — requesting read-only subset (%d tools).",
+             len(READ_ONLY_TOOLS))
+
+
+def _enforce_write_gate(mcp) -> None:
+    """Authoritative kill-switch (post-import): when writes are not allowed,
+    physically drop every write tool from the registry. The kill-switch wins
+    over any ENABLED_TOOLS allowlist — SHEETS_ALLOW_WRITE off means no write
+    tool is reachable, full stop. Independent of whether the package honored
+    ENABLED_TOOLS, so a future version regressing that feature cannot fail
+    open.
+    """
+    log = logging.getLogger(__name__)
+    if _writes_allowed():
+        log.warning("SHEETS_ALLOW_WRITE is on — write tools ENABLED.")
+        return
+    try:
+        registry = mcp._tool_manager._tools  # noqa: SLF001 - intentional
+    except AttributeError:
+        log.error("cannot reach tool registry to enforce write gate — "
+                  "refusing to start rather than expose writes.")
+        raise SystemExit(1)
+    removed = [name for name in WRITE_TOOLS if registry.pop(name, None) is not None]
+    log.info("write gate enforced: %d write tools removed, %d tools remain.",
+             len(removed), len(registry))
+
+
+def _check_credentials() -> None:
+    """Fail fast with a clear message if the SA base64 env is missing.
+
+    The package itself would fall back to ADC/OAuth and produce a confusing
+    error deep in the lifespan; surfacing it here keeps `docker logs` legible.
+    """
+    if not os.environ.get("CREDENTIALS_CONFIG"):
+        raise RuntimeError(
+            "CREDENTIALS_CONFIG env var is required (base64-encoded Google "
+            "service account JSON for the sheets-editor account). compose.yml "
+            "maps SHEETS_SERVICE_ACCOUNT_JSON_B64 -> CREDENTIALS_CONFIG."
+        )
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    _check_credentials()
+    _apply_write_gate()
+
+    # Importing the package builds the FastMCP `mcp` instance and registers
+    # every tool + the auth lifespan. _apply_write_gate() must precede this:
+    # the package reads ENABLED_TOOLS at import time.
+    from mcp_google_sheets.server import mcp
+
+    # Authoritative kill-switch — runs after registration so it cannot be
+    # bypassed by a version that ignores ENABLED_TOOLS.
+    _enforce_write_gate(mcp)
+
+    # FastMCP defaults to "/mcp"; the gateway forwards to "/". Override before
+    # serving. Belt-and-suspenders: set it on settings (used to build the ASGI
+    # app) regardless of the SDK minor version's attribute layout.
+    try:
+        mcp.settings.streamable_http_path = "/"
+    except AttributeError:  # pragma: no cover - SDK layout drift guard
+        logging.getLogger(__name__).warning(
+            "could not set streamable_http_path on mcp.settings; "
+            "relying on FASTMCP_STREAMABLE_HTTP_PATH env instead"
+        )
+
+    logging.getLogger(__name__).info(
+        "Google Sheets MCP starting on %s:%s (streamable-http, path=/)",
+        os.environ.get("HOST", "0.0.0.0"),
+        os.environ.get("PORT", "8080"),
+    )
+    mcp.run(transport="streamable-http")
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds **`/mcp/sheets`** — a read + write Google Sheets MCP, via the public `xing5/mcp-google-sheets` (FastMCP), served in-process over Streamable HTTP (same shape as ga4/google-ads, no supergateway).

## What it does
- 20 tools: 9 read (`get_sheet_data`, `list_*`, `search_spreadsheets`, `find_in_spreadsheet`, …) + 11 write (`update_cells`, `batch_update_cells`, `add_rows/columns`, `create_*`, `rename_sheet`, `share_spreadsheet`, `add_chart`).
- Single slug / single container — Sheets aren't brand-scoped; the model addresses each spreadsheet by ID.
- Auth: dedicated **`sheets-editor`** service account (NOT the read-only ga4-mcp-reader). Package reads `CREDENTIALS_CONFIG` (base64 SA JSON) directly — no /tmp file.

## Write kill-switch (mirrors dhl's `DHL_ALLOW_CREATE`)
`SHEETS_ALLOW_WRITE`, default **OFF**. Entrypoint requests the read-only subset via `ENABLED_TOOLS` **and** authoritatively pops all 11 write tools from the registry post-import — a future version dropping `ENABLED_TOOLS` support cannot fail open.

## Local verification (no Docker runtime)
- `tsc` ✓, YAML ✓, `py_compile` ✓.
- Pinned **0.6.3** (0.5.x had only 15 tools and **ignored `ENABLED_TOOLS`** → would have silently defeated the kill-switch).
- Gate OFF → 9 read, **0 write** reachable; gate ON → all 20.
- `streamable-http` + `streamable_http_path` override confirmed supported.
- **Memory:** idle RSS **~74 MB**, **no grpcio** (REST-only) → lighter than ga4/google-ads. `mem_limit` set to a tight **256m** (not ga4's loose 1500m) to protect neighbors on the 2 GB t4g.small.

## Pre-merge checklist (merge = deploy)
- [ ] Create `sheets-editor` SA in GCP; enable Sheets API + Drive API.
- [ ] Share each target spreadsheet with the SA's `client_email` (Editor).
- [ ] Set `SHEETS_SERVICE_ACCOUNT_JSON_B64` (+ `SHEETS_ALLOW_WRITE=true`) in the EC2 `.env`.
- [ ] HTTP smoke from EC2: `initialize` + `tools/list` against `/mcp/sheets/`.
- [ ] Sanity-check EC2 free memory (`free -m`) with the existing ~18 containers before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)