### PR TITLE
feat(warehouse): endpoint JSON read-only para el dashboard de Vercel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,24 @@ WORKER_SHARED_SECRET=
 
 # Postgres connection string for the data warehouse.
 # Use a dedicated read-only role, not the admin user.
+# Used by BOTH the warehouse MCP container AND the gateway's dashboard query
+# endpoint (POST /api/warehouse/query). The gateway runs every statement in a
+# READ ONLY transaction, but still use a read-only role here.
 WAREHOUSE_DATABASE_URL=postgresql://user:password@data-warehouse.cyeydevhei4c.us-east-1.rds.amazonaws.com:5432/warehouse
+
+# Optional: a STRICTER read-only role just for the gateway's JSON query endpoint
+# (kept separate from the MCP's role if you want different grants). Falls back to
+# WAREHOUSE_DATABASE_URL when unset.
+WAREHOUSE_READONLY_DATABASE_URL=
+
+# Optional: per-statement timeout (ms) for the dashboard query endpoint. Default 15000.
+WAREHOUSE_STATEMENT_TIMEOUT_MS=
+
+# NOTE: the dashboard query endpoint is gated by DASHBOARD_API_KEY, which is a
+# Cloudflare WORKER secret (not an EC2 .env var). Set it once with:
+#   cd worker && npx wrangler secret put DASHBOARD_API_KEY
+# Generate a strong value: openssl rand -hex 32
+# The same value goes into the Vercel project as WAREHOUSE_API_KEY.
 
 # --- Meta Ads MCP ---
 

--- a/compose.yml
+++ b/compose.yml
@@ -24,6 +24,15 @@ services:
       # ALLOWED_EMAIL_DOMAINS. Defaults inside auth.ts cover the same three
       # if the env is unset, so this is mainly for explicitness + override.
       ALLOWED_EMAIL_DOMAINS: ${ALLOWED_EMAIL_DOMAINS:-choiz.com.mx,choiz.com.ar,gotimeless.ai}
+      # Warehouse JSON query endpoint (POST /api/warehouse/query), consumed by
+      # the Vercel dashboard (kapso-ops-dashboard). The gateway connects to the
+      # RDS directly with pg and runs every statement in a READ ONLY transaction.
+      # Reuse the warehouse role (already read-only) or point
+      # WAREHOUSE_READONLY_DATABASE_URL at a stricter role. The Worker gates this
+      # endpoint with DASHBOARD_API_KEY (a wrangler secret) before forwarding.
+      WAREHOUSE_DATABASE_URL: ${WAREHOUSE_DATABASE_URL:?set WAREHOUSE_DATABASE_URL in .env}
+      WAREHOUSE_READONLY_DATABASE_URL: ${WAREHOUSE_READONLY_DATABASE_URL:-}
+      WAREHOUSE_STATEMENT_TIMEOUT_MS: ${WAREHOUSE_STATEMENT_TIMEOUT_MS:-15000}
       UPSTREAM_WAREHOUSE: "http://warehouse_mcp:8080"
       UPSTREAM_META_ADS: "http://meta_ads_mcp:8080"
       UPSTREAM_FACEBOOK_CHOIZ: "http://facebook_choiz_mcp:8080"

--- a/gateway/package-lock.json
+++ b/gateway/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.2.0",
       "dependencies": {
         "express": "^4.21.2",
-        "http-proxy-middleware": "^3.0.3"
+        "http-proxy-middleware": "^3.0.3",
+        "pg": "^8.13.1"
       },
       "devDependencies": {
         "@types/express": "^5.0.0",
         "@types/node": "^22.10.5",
+        "@types/pg": "^8.11.10",
         "tsx": "^4.19.2",
         "typescript": "^5.7.2"
       },
@@ -532,6 +534,18 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/qs": {
@@ -1348,6 +1362,95 @@
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
+      "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.13.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.14.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picomatch": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
@@ -1358,6 +1461,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -1577,6 +1719,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1685,6 +1836,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     }
   }

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -11,11 +11,13 @@
   },
   "dependencies": {
     "express": "^4.21.2",
-    "http-proxy-middleware": "^3.0.3"
+    "http-proxy-middleware": "^3.0.3",
+    "pg": "^8.13.1"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",
     "@types/node": "^22.10.5",
+    "@types/pg": "^8.11.10",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2"
   },

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import { createProxyMiddleware } from "http-proxy-middleware";
 import { authenticate, workerSecretOk } from "./auth.js";
+import { runReadOnlyQuery } from "./warehouse.js";
 
 const app = express();
 
@@ -101,6 +102,50 @@ app.get("/healthz", (_req, res) => {
     ],
   });
 });
+
+// --- Dashboard JSON query endpoint (machine-credentialed, NOT under /mcp) ---
+// The kapso-ops-dashboard (Vercel) reads the analytic `a.*` views over HTTPS
+// here instead of opening a socket to the private RDS. The Cloudflare Worker
+// validates the dashboard's API key and only then forwards the request with the
+// shared secret; we re-check the secret (same trust model as /dl/dhl) and run
+// the SQL read-only. Returns clean JSON: { rows: [...] }. Registered OUTSIDE the
+// /mcp guard because this caller is a machine, not a Google-authenticated user.
+const READ_ONLY_PREFIX = /^\s*(select|with|explain|table|values)\b/i;
+app.post(
+  "/api/warehouse/query",
+  express.json({ limit: "64kb" }),
+  async (req, res) => {
+    if (!workerSecretOk(req)) {
+      res.status(401).json({ error: "unauthorized" });
+      return;
+    }
+    const body = (req.body ?? {}) as { sql?: unknown; params?: unknown };
+    const sql = body.sql;
+    const params = body.params ?? [];
+    if (typeof sql !== "string" || !sql.trim()) {
+      res.status(400).json({ error: "missing_sql" });
+      return;
+    }
+    if (!Array.isArray(params)) {
+      res.status(400).json({ error: "params_must_be_array" });
+      return;
+    }
+    if (!READ_ONLY_PREFIX.test(sql)) {
+      // Defense-in-depth: the READ ONLY transaction already blocks writes, but
+      // we refuse anything that isn't obviously a read before it hits the DB.
+      res.status(400).json({ error: "only_read_queries_allowed" });
+      return;
+    }
+    try {
+      const rows = await runReadOnlyQuery(sql, params);
+      res.json({ rows });
+    } catch (err) {
+      // Never log SQL params or row contents (PII). Message + tag only.
+      console.error("[api/warehouse/query] failed:", (err as Error).message);
+      res.status(500).json({ error: "query_failed" });
+    }
+  },
+);
 
 // --- Auth guard for everything under /mcp ---
 app.use("/mcp", (req, res, next) => {

--- a/gateway/src/warehouse.ts
+++ b/gateway/src/warehouse.ts
@@ -1,0 +1,102 @@
+import { Pool, types, type QueryResultRow } from "pg";
+
+// ─────────────────────────────────────────────────────────────────────
+// Warehouse client for the dashboard JSON query endpoint (/api/warehouse/query).
+//
+// This is the ONLY place in the gateway that talks SQL to the RDS directly (the
+// warehouse MCP container has its own postgres-mcp connection). It exists so the
+// Vercel dashboard (kapso-ops-dashboard) can read the analytic views `a.*` over
+// HTTPS without a direct line to the private RDS: Vercel functions have dynamic
+// IPs and cannot reach the RDS, but they can reach this gateway (Cloudflare
+// Tunnel), which lives in the RDS's VPC.
+//
+// Safety: we connect with a read-only role AND run every statement inside a
+// READ ONLY transaction with a statement timeout, so even an over-privileged
+// role cannot write and a runaway query is bounded.
+//
+// Type parsers mirror the dashboard's old pg config so the JSON we return keeps
+// the exact contract the app expects:
+//   - bigint (INT8) / numeric → JS number (JSON has no bigint anyway)
+//   - timestamp / timestamptz / date → RAW string. The `a.*` views are already
+//     materialised in America/Mexico_City; reparsing to Date would shift them to
+//     the runtime's UTC and misalign the day buckets.
+// ─────────────────────────────────────────────────────────────────────
+
+const asNumber = (v: string | null): number | null =>
+  v === null ? null : Number(v);
+types.setTypeParser(types.builtins.INT8, asNumber); // bigint
+types.setTypeParser(types.builtins.NUMERIC, asNumber); // numeric / decimal
+
+const asString = (v: string | null): string | null => v;
+types.setTypeParser(types.builtins.TIMESTAMP, asString);
+types.setTypeParser(types.builtins.TIMESTAMPTZ, asString);
+types.setTypeParser(types.builtins.DATE, asString);
+
+// Prefer a dedicated read-only role; fall back to the same URL the warehouse
+// MCP uses (already read-only per .env convention).
+const connectionString =
+  process.env.WAREHOUSE_READONLY_DATABASE_URL ??
+  process.env.WAREHOUSE_DATABASE_URL;
+
+const STATEMENT_TIMEOUT_MS = (() => {
+  const n = Number(process.env.WAREHOUSE_STATEMENT_TIMEOUT_MS);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 15_000;
+})();
+
+let pool: Pool | null = null;
+
+function getPool(): Pool {
+  if (pool) return pool;
+  if (!connectionString) {
+    throw new Error(
+      "WAREHOUSE_DATABASE_URL (or WAREHOUSE_READONLY_DATABASE_URL) is required for /api/warehouse/query",
+    );
+  }
+  // RDS requires TLS but its cert is signed by the AWS CA (not in the system
+  // trust store). rejectUnauthorized=false encrypts without verifying the chain
+  // — same trade-off the dashboard made. Strip any sslmode= from the string so
+  // pg doesn't read it as verify-full and override our ssl object.
+  const cleaned = connectionString
+    .replace(/([?&])sslmode=[^&]*(&|$)/i, (_m, pre, post) =>
+      post === "&" ? pre : pre === "?" ? "" : "",
+    )
+    .replace(/[?&]$/, "");
+
+  pool = new Pool({
+    connectionString: cleaned,
+    ssl: { rejectUnauthorized: process.env.WAREHOUSE_SSL_STRICT === "true" },
+    max: 5,
+    idleTimeoutMillis: 30_000,
+    connectionTimeoutMillis: 10_000,
+  });
+  pool.on("error", (err) => {
+    // A dropped idle client must not crash the gateway process.
+    console.error("[warehouse] pool error:", err.message);
+  });
+  return pool;
+}
+
+/**
+ * Runs a single read-only SELECT against the warehouse and returns its rows.
+ * Wrapped in a READ ONLY transaction with a statement timeout: Postgres rejects
+ * any write inside it (defense in depth over the read-only role), and bounds a
+ * runaway query. Always called with parameters ($1, $2, ...) — never with
+ * values interpolated into the SQL.
+ */
+export async function runReadOnlyQuery<
+  T extends QueryResultRow = QueryResultRow,
+>(sql: string, params: ReadonlyArray<unknown>): Promise<T[]> {
+  const client = await getPool().connect();
+  try {
+    await client.query("BEGIN TRANSACTION READ ONLY");
+    await client.query(`SET LOCAL statement_timeout = ${STATEMENT_TIMEOUT_MS}`);
+    const res = await client.query<T>(sql, params as unknown[]);
+    await client.query("COMMIT");
+    return res.rows;
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+}

--- a/worker/src/default-handler.ts
+++ b/worker/src/default-handler.ts
@@ -27,6 +27,21 @@ type Bindings = WorkerEnv & { OAUTH_PROVIDER: OAuthHelpers };
 const app = new Hono<{ Bindings: Bindings }>();
 
 /**
+ * Constant-time string comparison. The length check leaks the key length, which
+ * is acceptable for a long random API key; the loop avoids leaking which byte
+ * differs. Workers have no Buffer.timingSafeEqual, so we roll our own.
+ */
+function timingSafeEqual(a: string, b: string): boolean {
+  const enc = new TextEncoder();
+  const ab = enc.encode(a);
+  const bb = enc.encode(b);
+  if (ab.length !== bb.length) return false;
+  let diff = 0;
+  for (let i = 0; i < ab.length; i++) diff |= ab[i] ^ bb[i];
+  return diff === 0;
+}
+
+/**
  * Step 1: claude.ai redirects the user here to start the flow.
  */
 app.get("/authorize", async (c) => {
@@ -167,6 +182,50 @@ app.get("/dl/dhl/:token", async (c) => {
     if (v) headers.set(h, v);
   }
   return new Response(upstream.body, { status: upstream.status, headers });
+});
+
+/**
+ * Machine-credentialed warehouse query endpoint for the Vercel dashboard
+ * (kapso-ops-dashboard). Lives here (NOT under /mcp/) so the OAuthProvider hands
+ * it to us with no bearer-token machinery — we do our own API-key check instead
+ * of the interactive Google OAuth flow that human MCP clients go through.
+ *
+ * Flow: dashboard -> POST /api/warehouse/query  (Authorization: Bearer <key>)
+ *   -> constant-time compare the key against DASHBOARD_API_KEY
+ *   -> forward the JSON body to the gateway with the shared secret
+ *   -> gateway runs it read-only against the RDS and returns { rows }.
+ */
+app.post("/api/warehouse/query", async (c) => {
+  const expected = c.env.DASHBOARD_API_KEY;
+  if (!expected) {
+    return c.json({ error: "endpoint_not_configured" }, 503);
+  }
+  const auth = c.req.header("authorization") ?? "";
+  const presented = auth.startsWith("Bearer ") ? auth.slice(7) : "";
+  if (!presented || !timingSafeEqual(presented, expected)) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+
+  // Cap the body so a bad/abusive caller can't stream an unbounded payload.
+  const payload = await c.req.text();
+  if (payload.length > 64 * 1024) {
+    return c.json({ error: "payload_too_large" }, 413);
+  }
+
+  const upstream = await fetch(`${c.env.UPSTREAM_BASE}/api/warehouse/query`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-worker-shared-secret": c.env.WORKER_SHARED_SECRET,
+    },
+    body: payload,
+  });
+  // The gateway only ever returns JSON here; pass status + body straight back.
+  const text = await upstream.text();
+  return new Response(text, {
+    status: upstream.status,
+    headers: { "content-type": "application/json" },
+  });
 });
 
 /**

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -10,6 +10,11 @@ export interface WorkerEnv extends Env {
   GOOGLE_CLIENT_ID: string;
   GOOGLE_CLIENT_SECRET: string;
   WORKER_SHARED_SECRET: string;
+  // Machine credential for the Vercel dashboard's /api/warehouse/query endpoint.
+  // Unlike the MCP surface (interactive Google OAuth), this is a long-lived key
+  // the dashboard backend presents as `Authorization: Bearer <key>`. Optional:
+  // if unset, the endpoint returns 503 (not configured).
+  DASHBOARD_API_KEY?: string;
 }
 
 /**


### PR DESCRIPTION
## Qué

Agrega `POST /api/warehouse/query` al gateway para que el dashboard **kapso-ops-dashboard** (Vercel) pueda leer las vistas `a.*` del warehouse por HTTPS, sin línea directa al RDS privado (las functions de Vercel tienen IP dinámica y no lo alcanzan).

## Cómo

- **Gateway** (`gateway/src/warehouse.ts` + ruta en `index.ts`): corre el SELECT con `pg` en una transacción **READ ONLY** (+ chequeo de prefijo `select/with/explain` + `statement_timeout`). Devuelve JSON limpio `{rows}`. Vive en la VPC del RDS, así que lo alcanza por red privada.
- **Worker** (`default-handler.ts`): gatea el endpoint con la API key de máquina `DASHBOARD_API_KEY` (constant-time), sin el OAuth de Google. Reenvía al gateway con el shared secret.
- **compose.yml**: pasa `WAREHOUSE_DATABASE_URL` (read-only) al servicio gateway.

## Seguridad

Read-only por triple barrera (rol + tx READ ONLY + prefijo). El Worker exige la key. Reusa la exposición pública que ya existe (Cloudflare Tunnel); no abre camino nuevo al RDS. El gateway no loguea SQL/params/filas (PII).

## Antes de mergear

Setear el secret en el Worker (ya hecho): `wrangler secret put DASHBOARD_API_KEY`. El merge dispara deploy de gateway + worker (reinicia el gateway unos segundos).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>