### PR TITLE
fix(warehouse): || en vez de ?? para el connection string del endpoint

### DIFF
--- a/gateway/src/warehouse.ts
+++ b/gateway/src/warehouse.ts
@@ -33,9 +33,11 @@ types.setTypeParser(types.builtins.TIMESTAMPTZ, asString);
 types.setTypeParser(types.builtins.DATE, asString);
 
 // Prefer a dedicated read-only role; fall back to the same URL the warehouse
-// MCP uses (already read-only per .env convention).
+// MCP uses (already read-only per .env convention). Use `||` (not `??`): compose
+// sets WAREHOUSE_READONLY_DATABASE_URL to an EMPTY STRING via `:-` when unset, and
+// `??` would keep that empty string instead of falling back to WAREHOUSE_DATABASE_URL.
 const connectionString =
-  process.env.WAREHOUSE_READONLY_DATABASE_URL ??
+  process.env.WAREHOUSE_READONLY_DATABASE_URL ||
   process.env.WAREHOUSE_DATABASE_URL;
 
 const STATEMENT_TIMEOUT_MS = (() => {


### PR DESCRIPTION
El endpoint POST /api/warehouse/query tiraba HTTP 500 `query_failed` con el log:
`WAREHOUSE_DATABASE_URL (or WAREHOUSE_READONLY_DATABASE_URL) is required`.

**Causa:** compose setea `WAREHOUSE_READONLY_DATABASE_URL` a string vacío (default `:-` cuando no está en .env). El `??` (nullish) NO cae al fallback con string vacío, así que `connectionString` quedaba `''` y el check `if (!connectionString)` tiraba el error. El contenedor SÍ tiene `WAREHOUSE_DATABASE_URL` con valor; solo había que preferirla.

**Fix:** `??` → `||` (cae al fallback también con vacío). Una línea.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>