### PR TITLE
Add read-only Viral Loops MCP (funnel + export)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -264,3 +264,36 @@ SHEETS_SERVICE_ACCOUNT_JSON_B64=
 # create_spreadsheet, create_sheet, copy_sheet, rename_sheet,
 # share_spreadsheet, add_chart). Flip back + restart to instantly stop writes.
 SHEETS_ALLOW_WRITE=
+
+# --- Viral Loops MCP (single tenant; READ-ONLY) ---
+#
+# Wraps the Viral Loops Web API v3 (app.viral-loops.com/api/v3). Only GET
+# endpoints are exposed (campaign info/stats + participant data/referrals/
+# rank/order/referrer/rewards) — there is no write surface. End users
+# authenticate to claude.ai with Google Workspace; the token below is what
+# talks to Viral Loops on their behalf.
+#
+# Auth: a single per-campaign token sent in the `apiToken` header. The token
+# is CAMPAIGN-SCOPED — it identifies which campaign you query, so there is NO
+# campaignId argument on any tool. Use the SECRET apiToken, NOT the client-safe
+# publicToken.
+#
+# How to obtain:
+#   Viral Loops dashboard → open your campaign → Settings / Installation → API
+#   (or "Developer Tools"). Copy the campaign's apiToken (the secret one, kept
+#   server-side — never the publicToken used in front-end widgets).
+# Static — no refresh. To rotate: regenerate in the dashboard and update here.
+VIRAL_LOOPS_API_TOKEN=
+
+# Optional base-URL override. Leave blank for the default
+# https://app.viral-loops.com/api/v3.
+VIRAL_LOOPS_BASE_URL=
+
+# Export download links (optional; sensible defaults baked in). export_participants
+# never inlines the full participant set — it stashes the CSV/JSON in-memory and
+# returns a browser link under this base. The gateway proxies
+# /dl/viral-loops/<token> -> the container's /download/<token>; the Worker exposes
+# it publicly (the ~192-bit token is the capability). Leave blank to use the
+# default. TTL controls link expiry (minutes).
+VIRAL_LOOPS_DOWNLOAD_BASE_URL=
+VIRAL_LOOPS_EXPORT_TTL_MINUTES=

--- a/.github/workflows/deploy-gateway.yml
+++ b/.github/workflows/deploy-gateway.yml
@@ -56,6 +56,7 @@ jobs:
       tiktok_organic: ${{ steps.filter.outputs.tiktok_organic }}
       dhl: ${{ steps.filter.outputs.dhl }}
       sheets: ${{ steps.filter.outputs.sheets }}
+      viral_loops: ${{ steps.filter.outputs.viral_loops }}
       compose: ${{ steps.filter.outputs.compose }}
     steps:
       - uses: actions/checkout@v4
@@ -89,6 +90,8 @@ jobs:
               - 'mcp/dhl/**'
             sheets:
               - 'mcp/sheets/**'
+            viral_loops:
+              - 'mcp/viral-loops/**'
             compose:
               - 'compose.yml'
 
@@ -445,13 +448,40 @@ jobs:
           cache-from: type=gha,scope=sheets
           cache-to: type=gha,mode=max,scope=sheets
 
+  build-viral-loops:
+    name: Build viral-loops image
+    needs: changes
+    if: needs.changes.outputs.viral_loops == 'true' || needs.changes.outputs.compose == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./mcp/viral-loops
+          push: true
+          platforms: linux/arm64
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/viral-loops:latest
+            ${{ env.IMAGE_PREFIX }}/viral-loops:${{ github.sha }}
+          cache-from: type=gha,scope=viral-loops
+          cache-to: type=gha,mode=max,scope=viral-loops
+
   deploy:
     name: Deploy on EC2 via SSM
-    needs: [build-gateway, build-warehouse, build-meta-ads, build-facebook, build-instagram, build-google-ads, build-ga4, build-gsc, build-shopify, build-powerbi, build-tiktok-organic, build-dhl, build-sheets]
+    needs: [build-gateway, build-warehouse, build-meta-ads, build-facebook, build-instagram, build-google-ads, build-ga4, build-gsc, build-shopify, build-powerbi, build-tiktok-organic, build-dhl, build-sheets, build-viral-loops]
     # Run only if at least one build succeeded. If all builds were skipped
     # (because nothing relevant changed, e.g. workflow-only edit), do not
     # touch the EC2 — there's nothing to deploy.
-    if: ${{ !cancelled() && !failure() && (needs.build-gateway.result == 'success' || needs.build-warehouse.result == 'success' || needs.build-meta-ads.result == 'success' || needs.build-facebook.result == 'success' || needs.build-instagram.result == 'success' || needs.build-google-ads.result == 'success' || needs.build-ga4.result == 'success' || needs.build-gsc.result == 'success' || needs.build-shopify.result == 'success' || needs.build-powerbi.result == 'success' || needs.build-tiktok-organic.result == 'success' || needs.build-dhl.result == 'success' || needs.build-sheets.result == 'success') }}
+    if: ${{ !cancelled() && !failure() && (needs.build-gateway.result == 'success' || needs.build-warehouse.result == 'success' || needs.build-meta-ads.result == 'success' || needs.build-facebook.result == 'success' || needs.build-instagram.result == 'success' || needs.build-google-ads.result == 'success' || needs.build-ga4.result == 'success' || needs.build-gsc.result == 'success' || needs.build-shopify.result == 'success' || needs.build-powerbi.result == 'success' || needs.build-tiktok-organic.result == 'success' || needs.build-dhl.result == 'success' || needs.build-sheets.result == 'success' || needs.build-viral-loops.result == 'success') }}
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -62,3 +62,7 @@ services:
   sheets_mcp:
     build: ./mcp/sheets
     image: ghcr.io/choizapp/choiz-mcp-gateway/sheets:dev
+
+  viral_loops_mcp:
+    build: ./mcp/viral-loops
+    image: ghcr.io/choizapp/choiz-mcp-gateway/viral-loops:dev

--- a/compose.yml
+++ b/compose.yml
@@ -50,6 +50,7 @@ services:
       UPSTREAM_TIKTOK_ORGANIC_CHOIZ: "http://tiktok_organic_choiz_mcp:8080"
       UPSTREAM_DHL: "http://dhl_mcp:8080"
       UPSTREAM_SHEETS: "http://sheets_mcp:8080"
+      UPSTREAM_VIRAL_LOOPS: "http://viral_loops_mcp:8080"
       # Remote MCPs proxied through the gateway (no internal container).
       # The route is only registered if the corresponding API key is set;
       # gateway/src/index.ts logs a skip-warning otherwise. See memory
@@ -87,6 +88,7 @@ services:
       - tiktok_organic_choiz_mcp
       - dhl_mcp
       - sheets_mcp
+      - viral_loops_mcp
     restart: unless-stopped
 
   warehouse_mcp:
@@ -422,6 +424,40 @@ services:
       # *_SERVICE_ACCOUNT_JSON_B64 convention on the .env side and alias here.
       CREDENTIALS_CONFIG: ${SHEETS_SERVICE_ACCOUNT_JSON_B64:?set SHEETS_SERVICE_ACCOUNT_JSON_B64 in .env}
       SHEETS_ALLOW_WRITE: ${SHEETS_ALLOW_WRITE:-false}
+    mem_limit: 256m
+    pids_limit: 100
+    restart: unless-stopped
+
+  # Viral Loops MCP — single tenant, READ-ONLY. Custom FastMCP server
+  # (mcp/viral-loops/entrypoint.py) wrapping the Viral Loops Web API v3 over
+  # HTTPS with a per-campaign apiToken header. Mirrors the dhl shape:
+  # requests + stateless_http, no SDK. Only GET endpoints are wired (campaign
+  # info/stats + participant data/referrals/rank/order/referrer/rewards), so
+  # unlike dhl there is no write surface to guard.
+  #
+  # Auth: VIRAL_LOOPS_API_TOKEN — the campaign's SECRET apiToken (not the
+  # client-safe publicToken). The token identifies the campaign; there is no
+  # campaignId argument. Static, no refresh. Single tenant: one campaign per
+  # container. To add a per-brand campaign later, copy this block to a
+  # viral_loops_<brand>_mcp service + add an UPSTREAM_VIRAL_LOOPS_<BRAND> entry
+  # and a /mcp/viral-loops-<brand> route — the image is brand-agnostic.
+  #
+  # mem_limit TIGHT 256m (matches sheets): REST-only stack, no heavy SDK; idle
+  # RSS is tens of MB. A leak OOM-kills only this container (restart:
+  # unless-stopped) instead of evicting a neighbor on the t4g.small.
+  viral_loops_mcp:
+    image: ghcr.io/choizapp/choiz-mcp-gateway/viral-loops:${IMAGE_TAG:-latest}
+    environment:
+      VIRAL_LOOPS_API_TOKEN: ${VIRAL_LOOPS_API_TOKEN:?set VIRAL_LOOPS_API_TOKEN in .env}
+      # Optional override; defaults to https://app.viral-loops.com/api/v3 inside
+      # the entrypoint. Leave unset in normal operation.
+      VIRAL_LOOPS_BASE_URL: ${VIRAL_LOOPS_BASE_URL:-}
+      # export_participants stashes the CSV/JSON in-memory and returns a
+      # browser-openable link under this base. The gateway proxies
+      # /dl/viral-loops/<token> -> this container's /download/<token>; the Worker
+      # exposes it publicly (the token is the capability). TTL in minutes.
+      VIRAL_LOOPS_DOWNLOAD_BASE_URL: ${VIRAL_LOOPS_DOWNLOAD_BASE_URL:-https://mcp.choiz.com.mx/dl/viral-loops}
+      VIRAL_LOOPS_EXPORT_TTL_MINUTES: ${VIRAL_LOOPS_EXPORT_TTL_MINUTES:-30}
     mem_limit: 256m
     pids_limit: 100
     restart: unless-stopped

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -50,6 +50,11 @@ const upstreams: Record<string, string | undefined> = {
   // unlike dhl the blast radius is "any Sheet shared with the SA", so keep
   // the SA's sharing surface tight.
   "/mcp/sheets":               process.env.UPSTREAM_SHEETS,
+  // Viral Loops MCP — single tenant, READ-ONLY. Custom FastMCP server
+  // (mcp/viral-loops/entrypoint.py) wrapping the Viral Loops Web API v3 with a
+  // per-campaign apiToken. The campaign IS the token, so there is no campaignId
+  // argument on any tool. Only GET endpoints are exposed.
+  "/mcp/viral-loops":          process.env.UPSTREAM_VIRAL_LOOPS,
 };
 
 // --- Remote MCPs proxied through the gateway (no internal container) ---
@@ -253,6 +258,51 @@ if (dhlDownloadTarget) {
         },
         error: (err, _req, res) => {
           console.error("[proxy:/dl/dhl] upstream error", err);
+          if (res && "writeHead" in res && !res.headersSent) {
+            res.writeHead(502, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: "upstream_unavailable" }));
+          }
+        },
+      },
+    }),
+  );
+}
+
+// --- Viral Loops export download (public capability URL, NOT under /mcp) ---
+// Same trust model as /dl/dhl: browser GET mcp.choiz.com.mx/dl/viral-loops/<token>
+// -> Worker (no bearer) -> here. The unguessable token is the authorization; we
+// only verify the request came from the Worker (shared secret), then proxy to
+// the viral-loops MCP container's GET /download/<token>. export_participants
+// stashes the CSV/JSON in-container and hands back this link instead of inlining
+// tens of thousands of rows.
+const viralLoopsDownloadTarget = process.env.UPSTREAM_VIRAL_LOOPS;
+if (viralLoopsDownloadTarget) {
+  app.use(
+    "/dl/viral-loops",
+    (req, res, next) => {
+      if (!workerSecretOk(req)) {
+        res.status(401).json({ error: "unauthorized" });
+        return;
+      }
+      next();
+    },
+    createProxyMiddleware({
+      target: viralLoopsDownloadTarget,
+      changeOrigin: true,
+      // Express strips the "/dl/viral-loops" mount prefix before the proxy runs,
+      // so pathRewrite sees the already-stripped "/<token>". Rewrite the leading
+      // slash to "/download/" so the MCP receives /download/<token>.
+      pathRewrite: { "^/": "/download/" },
+      selfHandleResponse: false,
+      on: {
+        proxyReq: (proxyReq) => {
+          // Never leak our internal headers to the container.
+          proxyReq.removeHeader("x-worker-shared-secret");
+          proxyReq.removeHeader("x-choiz-user-email");
+          proxyReq.removeHeader("x-mcp-user");
+        },
+        error: (err, _req, res) => {
+          console.error("[proxy:/dl/viral-loops] upstream error", err);
           if (res && "writeHead" in res && !res.headersSent) {
             res.writeHead(502, { "Content-Type": "application/json" });
             res.end(JSON.stringify({ error: "upstream_unavailable" }));

--- a/mcp/viral-loops/Dockerfile
+++ b/mcp/viral-loops/Dockerfile
@@ -1,0 +1,32 @@
+# Viral Loops MCP — custom server, no upstream package to wrap.
+#
+# Talks to the Viral Loops Web API v3 (app.viral-loops.com/api/v3) over HTTPS
+# with a per-campaign `apiToken` header. End users authenticate to claude.ai
+# with Google Workspace; they never see a Viral Loops login.
+#
+# READ-ONLY: only GET endpoints are exposed (campaign info/stats + participant
+# data/referrals/rank/order/referrer/rewards). Mirrors the dhl / tiktok-organic
+# shape: FastMCP + requests, stateless_http=True, no SDK.
+
+FROM python:3.12-slim
+
+# ca-certificates: HTTPS to app.viral-loops.com.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Pin mcp to 1.25.0 to match the rest of the stack (warehouse / facebook /
+# instagram / ga4 / powerbi / tiktok-organic / dhl). requests for the HTTP calls.
+RUN pip install --no-cache-dir \
+    'mcp==1.25.0' \
+    'requests>=2.31,<3'
+
+ENV PYTHONUNBUFFERED=1
+
+COPY entrypoint.py /opt/entrypoint.py
+
+EXPOSE 8080
+
+ENTRYPOINT ["python", "/opt/entrypoint.py"]

--- a/mcp/viral-loops/PLAN.md
+++ b/mcp/viral-loops/PLAN.md
@@ -1,0 +1,147 @@
+# Viral Loops MCP — funnel + hardening plan
+
+Execute this in a fresh session. It turns the current read-only Viral Loops MCP
+(per-participant lookups) into something that can actually answer the PM funnel
+question **without flooding claude.ai's context**, plus applies agreed code fixes.
+
+The funnel need (Sergio): build the referral program's **end-to-end funnel over
+the last few months, in absolutes and rates**. The Viral-Loops-owned steps are:
+referral link generated → referred lead loads email → referred user pays
+(conversion attributed to a referrer). Top-of-funnel (active users, app access,
+in-app referral-section visits) comes from Mixpanel + BI, NOT this server.
+
+---
+
+## 0. Current state (read before starting)
+
+- **Repo:** `c:/Users/uriel/A/_dev/ctl/common/data/choiz-mcp-gateway` (its own git repo, default branch `master`).
+- **Git:** Mixpanel work is committed on branch **`feat/mixpanel-mcp`** (`e0907f5`). The **Viral Loops work is UNCOMMITTED** in the working tree on that branch:
+  - new: `mcp/viral-loops/{entrypoint.py, Dockerfile}` (+ this `PLAN.md`)
+  - edited: `gateway/src/index.ts`, `compose.yml`, `compose.dev.yml`, `.env.example`, `.github/workflows/deploy-gateway.yml`
+  - **First step (task 0): move VL changes onto their own branch off `master`.** See below.
+- **The VL MCP already works** (verified live): FastMCP + requests, `stateless_http=True`, serves at `/`, 8 read-only tools, compact JSON. Local docker build + `initialize`/`tools/list`/`tools/call` all pass.
+- **Mixpanel is done** — don't touch it.
+
+## Verified API facts (do NOT re-derive)
+
+- Base URL: `https://app.viral-loops.com/api/v3` (override env `VIRAL_LOOPS_BASE_URL`).
+- Auth: single header `apiToken: <token>`. **Campaign-scoped — no campaignId on any call.** Token is in `.env` as `VIRAL_LOOPS_API_TOKEN` (gitignored, present locally; NOT deployed — EC2 `.env` needs it set over SSM).
+- Verified GET paths (in `PATHS` in entrypoint.py): `/campaign/data`, `/campaign/stats` (lifetime `leadCount`/`referralCountTotal`/`conversionCountTotal`, **no date filter**), `/campaign/participant/{data,referrals,rank,order,referrer}`, `/campaign/participant/rewards/{given,pending}`.
+- Participant identifier = `referralCode` and/or `email` (NOT `user_id`).
+- **`POST /campaign/participant/query`** returns **rows, 50/page**: `{"data": [ {user, referrer, counters}, ... ]}`. **No server-side count.** A naive `{"filter":{"createdAt":{"$gte":"..."}}}` returns HTTP 400 — the real filter/pagination schema is UNKNOWN and is task 1.
+- **`POST /campaign/participant/search`** exists; empty body → 400 (needs a body; schema unknown).
+- claude.ai silently rejects MCP tool results larger than **~2–3 KB**.
+
+---
+
+## Task 0 — Git hygiene
+
+```bash
+cd .../choiz-mcp-gateway
+# from feat/mixpanel-mcp with VL changes in the working tree:
+git stash -u                      # stash VL edits + untracked mcp/viral-loops/
+git checkout master
+git checkout -b feat/viral-loops
+git stash pop                     # VL changes now on feat/viral-loops
+git status                        # confirm only VL files changed; mixpanel NOT present
+```
+(If `git stash pop` conflicts on the shared files because the mixpanel commit isn't in master, instead cherry-pick or just re-apply — the VL hunks in `gateway/src/index.ts`/`compose.yml`/`.env.example` are independent of the mixpanel hunks, so a clean 3-way usually applies. Verify `grep -ri mixpanel` shows nothing staged.)
+
+## Task 1 — Discover the `/query` (and `/search`) filter + pagination schema  ← do FIRST; tasks 3 & 4 depend on it
+
+Goal: find how to (a) filter by **date range**, (b) filter by **conversion status / has-referrer**, (c) **paginate** (skip/limit/page/count?), and (d) whether any response carries a **total count**.
+
+Recipe (write curl output to a **repo-relative** file — native Windows python can't read `/tmp`):
+```bash
+VLT=$(grep '^VIRAL_LOOPS_API_TOKEN=' .env | cut -d= -f2-); BASE="https://app.viral-loops.com/api/v3"
+# vary the body; inspect keys + whether 'data' length changes / a count appears
+curl -s -X POST "$BASE/campaign/participant/query" -H "apiToken: $VLT" -H "content-type: application/json" -d '{"filter":{}}' -o q.json -w "%{http_code}\n"
+```
+Things to try in the body: `{"limit":N,"skip":M}`, `{"page":1,"count":N}`, `{"filter":{...}}` with date keys like `joinedAt`/`createdAt`/`registeredAt` and operators the API actually accepts (the `$gte` guess failed — try ISO strings, epoch ms, `{from,to}` shapes), and conversion fields (look at what a real row's `counters`/`referrer`/`converted` fields are named — dump ONE row's keys+values for a converted vs non-converted participant). Also probe `/search` with a minimal valid body. **Document the working schema at the top of entrypoint.py.** If no count and no efficient server-side aggregation exists, note it — it changes task 3's design (see risk below).
+
+Sanity cross-check: whatever totals you compute over "all time" should reconcile with `/campaign/stats` (`leadCount`, `referralCountTotal`, `conversionCountTotal`).
+
+## Task 2 — Code fixes (the 2 review findings + 2 hardening adds)
+
+In `mcp/viral-loops/entrypoint.py`:
+
+1. **Validate `status`** in `get_participant_rewards` (don't silently fall back to "given"):
+   ```python
+   s = status.strip().lower()
+   if s not in ("given", "pending"):
+       raise ValueError('status must be "given" or "pending"')
+   key = "rewards_pending" if s == "pending" else "rewards_given"
+   ```
+2. **Bound `page`/`count`** in `get_participant_referrals` (clamp, don't raise):
+   ```python
+   _MAX_REFERRALS_COUNT = 25   # module constant; ~fits the 2-3 KB ceiling
+   page = max(1, int(page)); count = min(max(1, int(count)), _MAX_REFERRALS_COUNT)
+   ```
+   Note the clamp in the docstring.
+3. **429 retry/backoff** in `_get` (add `import time`): retry up to 3x on 429, honor `Retry-After` (clamp 0.5–5 s). VL caps 300/min.
+4. **Clean empty-200**: an empty 2xx body (e.g. participant with no referrer) currently returns `{"raw":""}`; make it return `"null"`.
+
+## Task 3 — `get_referral_funnel(start, end)` — server-side aggregation (Option A)
+
+A new tool that paginates `/query` (or `/search`) **internally**, counts, and returns a **small** funnel object — NOT rows. Target output (~a few hundred bytes):
+```json
+{"window":{"start":"...","end":"..."},
+ "referrers_with_link": N, "referred_leads": N, "conversions": N,
+ "rates":{"lead_to_referrer":x,"referrer_to_referred":x,"referred_to_conversion":x}}
+```
+Map the three counts to the real `/query` row fields discovered in task 1 (referral generated = participant has a referralCode / is flagged as referrer; referred lead = participant has a `referrer`; conversion = referred participant with a converted timestamp/counter). Add a `group_by="month"` variant if cheap.
+
+**Design risk (decide after task 1):** if `/query` only returns rows (50/page, no count, no aggregate), a full campaign pass is ~820 requests for ~41k leads (~3 min, rate-limit-bound). Mitigations, in order of preference:
+- a date-bounded window keeps the row set small → fine to paginate;
+- if VL exposes any count/aggregate or a stats-with-date endpoint (task 1), use it;
+- otherwise cap the window and `log()` if truncated, and lean on Task 4 (export) for big pulls.
+Keep all looping/counting server-side so only the small summary crosses the tool channel.
+
+## Task 4 — `export_participants(...)` → download URL (Option B; your file-download ask)
+
+Mirror the **DHL externalization pattern** already in this repo — the cleanest reference:
+- `mcp/dhl/entrypoint.py`: `_store_label()` (in-memory TTL store keyed by `secrets.token_urlsafe`), `@mcp.custom_route("/download/{token}", methods=["GET"])`, and `LABEL_DOWNLOAD_BASE_URL`.
+- `gateway/src/index.ts`: the `/dl/dhl` block (public capability URL, NOT under `/mcp` auth, verifies worker shared secret, strips internal headers, rewrites `^/` → `/download/`).
+
+Build:
+- A tool that pulls the full filtered participant set (paginate `/query`), writes a **CSV or JSON** to an in-memory TTL store, returns a short `{"download_url": "https://mcp.choiz.com.mx/dl/viral-loops/<token>", "rows": N, "expires_in_minutes": ...}`. The tool result is just the URL → **no context flood**.
+- A `/download/{token}` custom route in the entrypoint + a new **`/dl/viral-loops`** proxy block in `gateway/src/index.ts` (copy the dhl one, swap the upstream env to `UPSTREAM_VIRAL_LOOPS`).
+- Env: `VIRAL_LOOPS_DOWNLOAD_BASE_URL` (default `https://mcp.choiz.com.mx/dl/viral-loops`) + a TTL, added to `compose.yml` + `.env.example`.
+
+**Consumption caveat to put in the tool docstring:** in claude.ai the analysis sandbox has **no outbound network**, so Claude can't fetch the URL itself — the user downloads it (or re-uploads it to Claude as an attachment to script over). In Claude Code the agent can `curl` it directly.
+
+## Task 5 — Wire, validate, test
+
+- If task 4 added the `/dl/viral-loops` route: update `gateway/src/index.ts` (done in task 4), and confirm `compose.yml` passes the new env to `viral_loops_mcp`.
+- Validate:
+  - `cd gateway && npx tsc --noEmit -p tsconfig.json` → exit 0.
+  - `docker compose -f compose.yml -f compose.dev.yml config` (set the `:?`-required envs to dummy values inline) → exit 0.
+  - `python -m py_compile mcp/viral-loops/entrypoint.py`.
+- Live test (docker daemon must be up):
+  ```bash
+  docker build -t vl-test ./mcp/viral-loops
+  docker rm -f vl >/dev/null 2>&1
+  VLT=$(grep '^VIRAL_LOOPS_API_TOKEN=' .env | cut -d= -f2-)
+  docker run -d --name vl -e VIRAL_LOOPS_API_TOKEN="$VLT" -p 8099:8080 vl-test
+  # initialize + tools/list + tools/call for get_referral_funnel and export_participants
+  ```
+  Confirm: funnel returns small numbers that reconcile with `/campaign/stats`; export returns a URL; `GET /download/<token>` on :8099 serves the file; `status="bad"` errors; no-referrer → `null`. Then `docker rm -f vl`.
+
+## Task 6 — Commit
+
+One commit on `feat/viral-loops`: "Add read-only Viral Loops MCP (funnel + export)". Don't commit `.env`. Optionally delete this `PLAN.md` before committing (or keep it — your call).
+
+---
+
+## Gotchas (learned the hard way)
+
+- **Native Windows python can't read `/tmp`** — curl (git bash) writes there fine, but `python.exe` resolves `/tmp` to `C:\tmp`. Use repo-relative temp files for any python read step.
+- **FastMCP pretty-prints dict returns** → inflates payload vs the 2–3 KB ceiling. The MCP already returns **compact JSON strings** via `_get`; keep new tools doing the same (return `str`, `json.dumps(..., separators=(",",":"))`). Annotate tools `-> str` (also dodges FastMCP outputSchema rejection).
+- **`streamable_http_path="/"` + `stateless_http=True` + `host="0.0.0.0"`** are required (gateway strips `/mcp/viral-loops` and forwards to `/`).
+- **6 wiring touchpoints for a container MCP** (already done for the base; only revisit if task 4 adds the `/dl` route or new env): `gateway/src/index.ts`, `compose.yml` (env + depends_on + service), `compose.dev.yml`, `.env.example`, `.github/workflows/deploy-gateway.yml` (changes filter + `build-viral-loops` job + deploy `needs`/`if`).
+- **Deploy:** EC2 `.env` needs `VIRAL_LOOPS_API_TOKEN` over SSM (+ any new export env); gateway image must redeploy if `gateway/src/index.ts` changed (route table is compiled in).
+
+## Explicitly out of scope
+
+- **Option C (ETL → warehouse).** Dropped per decision. If ever revisited: a SEPARATE loader job lands VL data in the warehouse; analysts read via the EXISTING read-only `warehouse` MCP. No new MCP write access — this MCP stays read-only.
+- Mixpanel (already committed).

--- a/mcp/viral-loops/entrypoint.py
+++ b/mcp/viral-loops/entrypoint.py
@@ -1,0 +1,826 @@
+"""Viral Loops MCP — READ-ONLY access to a Viral Loops referral campaign.
+
+Wraps the Viral Loops Web API v3 (https://app.viral-loops.com/api/v3). Custom
+FastMCP + requests server, no upstream package to wrap — the surface we use is a
+handful of GET endpoints. Mirrors the dhl / tiktok-organic shape:
+FastMCP + requests, stateless_http=True, no SDK.
+
+READ-ONLY by design. Viral Loops' write surface (register participant, convert,
+flag, edit, redeem rewards) is deliberately NOT exposed — none of the POST/PUT
+endpoints are wired. The only way in is the gateway auth chain
+(x-worker-shared-secret + Google Workspace email).
+
+Auth model
+----------
+Viral Loops authenticates with a per-campaign token sent in the ``apiToken``
+HTTP header. The token is CAMPAIGN-SCOPED: it identifies which campaign you are
+querying, so there is no separate campaignId parameter on any call. Use the
+secret ``apiToken`` (server-side), NOT the ``publicToken`` (client-safe, fewer
+permissions). Get it from the Viral Loops dashboard → your campaign → Settings /
+Installation → API. Static — no refresh.
+
+Single tenant: one campaign = one VIRAL_LOOPS_API_TOKEN in env. If Choiz ever
+runs separate Viral Loops campaigns per brand, follow the gateway multi-tenant
+pattern (one image, N containers + N slugs, e.g. /mcp/viral-loops-choiz) — the
+container code here is already brand-agnostic.
+
+claude.ai payload ceiling
+-------------------------
+claude.ai silently rejects MCP tool results above ~2-3 KB (see
+ADDING_AN_MCP.md). Tool returns here are serialized as COMPACT JSON (no indent)
+and the list endpoint (referrals) defaults to a small page size; raise it
+explicitly only when needed.
+
+All v3 REST paths + the participant identifier (referralCode / email) were
+verified against the live API on 2026-06-18 with a real campaign token. The
+token alone scopes every call to its campaign — no campaignId is ever sent.
+
+Bulk participant access — /campaign/participant/search (verified 2026-06-18)
+---------------------------------------------------------------------------
+The ONLY paginated bulk endpoint. POST a body of exactly::
+
+    {"pagination": {"limit": <1..100>, "offset": <int>}}
+
+and it returns a flat JSON LIST of participant rows (NOT wrapped in ``data``).
+Hard facts established by probing the live API:
+  * ``limit`` is capped at 100 (HTTP 400 above it). ``offset`` paginates.
+  * There is NO server-side filter, sort, or total count. ``filter`` / ``sort``
+    / ``orderBy`` / date keys in the body are SILENTLY IGNORED. Default order is
+    by rank (referralCountTotal desc), stable enough for offset paging.
+  * An offset PAST the end returns HTTP 503 (not an empty list), so a scan must
+    stop the moment a page returns fewer than ``limit`` rows.
+Each row is flat, e.g.::
+
+    {"id":52117063, "email":..., "referralCode":..., "createdAt":"2023-10-18T15:12:29.000Z",
+     "referrerId":0, "referrerEmail":null, "referrerReferralCode":null,
+     "referralCountTotal":86, "conversionCountTotal":25, "converted":0, "rank":1, ...}
+
+Funnel field mapping (RECONCILED against /campaign/stats over the full ~41k set
+on 2026-06-18 — leadCount 40956 / referralCountTotal 4606 / conversionCountTotal
+1540):
+  * lead / "referral link generated" = any participant (each gets a referralCode
+    + uniqueLink on join). Count of all rows ≈ leadCount.
+  * referrer who actually referred  = referralCountTotal > 0   (2225 observed).
+  * referred lead "loads email"     = referrerId set (>0) / referrerReferralCode
+    not null  (4605 observed ≈ referralCountTotal 4606).
+  * conversion "referred user pays" = converted == 1 (1539 observed ≈
+    conversionCountTotal 1540); every converted participant is also a referred
+    one, so conversions are a strict subset of referred leads.
+``createdAt`` is the participant's JOIN time. The API exposes NO per-referral or
+per-conversion timestamp and NO server-side date filter, so any date window is
+applied CLIENT-SIDE by join date over a FULL campaign scan (see _scan_participants).
+"""
+from __future__ import annotations
+
+import csv
+import io
+import json
+import logging
+import os
+import random
+import secrets
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import requests
+from mcp.server.fastmcp import FastMCP
+from starlette.requests import Request
+from starlette.responses import Response
+
+logger = logging.getLogger("viral_loops_mcp")
+logging.basicConfig(
+    level=os.environ.get("LOG_LEVEL", "INFO"),
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+
+# --- Config from env ------------------------------------------------------
+
+API_TOKEN = os.environ["VIRAL_LOOPS_API_TOKEN"]
+BASE_URL = (
+    os.environ.get("VIRAL_LOOPS_BASE_URL") or "https://app.viral-loops.com/api/v3"
+).rstrip("/")
+
+# Single source of truth for the v3 REST paths. All verified against the live
+# API on 2026-06-18 with a real campaign token.
+PATHS = {
+    "campaign":          "/campaign/data",                  # public campaign info/config
+    "stats":             "/campaign/stats",                 # leads + total referrals + conversions
+    "participant":       "/campaign/participant/data",      # one participant's data
+    "referrals":         "/campaign/participant/referrals", # who a participant referred
+    "rank":              "/campaign/participant/rank",       # leaderboard / waitlist rank
+    "order":             "/campaign/participant/order",      # join order position
+    "referrer":          "/campaign/participant/referrer",   # who referred this participant
+    "rewards_given":     "/campaign/participant/rewards/given",
+    "rewards_pending":   "/campaign/participant/rewards/pending",
+}
+
+# Page-size ceiling for get_participant_referrals. ~25 referral rows is about
+# as much as fits under claude.ai's ~2-3 KB tool-result ceiling.
+_MAX_REFERRALS_COUNT = 25
+
+# Rate-limit handling. Viral Loops caps requests at 300/min; on a 429 it may
+# send a Retry-After header. Retry a few times, honoring Retry-After clamped to
+# a sane band so a hostile/garbage value can't stall the tool call.
+_RATE_LIMIT_RETRIES = 3
+_RETRY_AFTER_MIN_S = 0.5
+_RETRY_AFTER_MAX_S = 5.0
+
+# Bulk-scan retry policy (used by _post, i.e. the /search pager). The scan runs
+# several requests concurrently, so it brushes Viral Loops' burst limit more
+# than interactive single GETs do — Cloudflare answers a burst with a 429
+# "Too Many Requests" HTML page. Be PATIENT here: more attempts, exponential
+# backoff up to 30 s (honoring Retry-After), plus jitter so concurrent workers
+# don't resynchronize into another simultaneous burst (thundering herd).
+_SCAN_MAX_RETRIES = 6
+_SCAN_BACKOFF_CAP_S = 30.0
+
+_SESSION = requests.Session()
+_SESSION.headers.update({"apiToken": API_TOKEN, "Accept": "application/json"})
+
+
+# --- HTTP helpers ---------------------------------------------------------
+
+
+def _retry_after_seconds(resp: requests.Response, attempt: int) -> float:
+    """Seconds to wait before a 429 retry. Honor Retry-After if present
+    (clamped to [_RETRY_AFTER_MIN_S, _RETRY_AFTER_MAX_S]); otherwise back off
+    linearly by attempt within the same band."""
+    raw = resp.headers.get("Retry-After")
+    if raw:
+        try:
+            wait = float(raw)
+        except ValueError:
+            wait = _RETRY_AFTER_MIN_S * (attempt + 1)
+    else:
+        wait = _RETRY_AFTER_MIN_S * (attempt + 1)
+    return max(_RETRY_AFTER_MIN_S, min(wait, _RETRY_AFTER_MAX_S))
+
+
+def _parse_body(resp: requests.Response) -> Any:
+    try:
+        return resp.json()
+    except ValueError:
+        # An empty 2xx body (e.g. a participant with no referrer) decodes to
+        # nothing; represent it as JSON null rather than {"raw": ""}.
+        if not resp.text.strip():
+            return None
+        return {"raw": resp.text}
+
+
+def _raise_for_error(resp: requests.Response, method: str, path: str, data: Any) -> None:
+    msg = None
+    if isinstance(data, dict):
+        msg = data.get("message") or data.get("error") or data.get("detail") or data.get("description")
+    raise RuntimeError(
+        f"Viral Loops API error on {method} {path} (HTTP {resp.status_code})"
+        + (f": {msg}" if msg else f": {str(data)[:300]}")
+    )
+
+
+def _get(path: str, params: dict[str, Any] | None = None) -> str:
+    """Authenticated GET against the Viral Loops v3 API.
+
+    Returns the response as a COMPACT JSON string (no indentation): FastMCP
+    pretty-prints dict returns, which inflates payloads against claude.ai's
+    ~2-3 KB tool-result ceiling (see ADDING_AN_MCP.md). Retries on HTTP 429
+    (honoring Retry-After). Raises RuntimeError on other non-2xx so the model
+    gets actionable feedback rather than a silent empty result — Viral Loops
+    error bodies usually carry a ``message`` / ``error``. An empty 2xx body is
+    returned as the JSON literal ``"null"``.
+    """
+    url = f"{BASE_URL}{path}"
+    # Drop None/empty params so we never send e.g. ?email=
+    clean = {k: v for k, v in (params or {}).items() if v not in (None, "")}
+    for attempt in range(_RATE_LIMIT_RETRIES + 1):
+        resp = _SESSION.get(url, params=clean, timeout=30)
+        if resp.status_code == 429 and attempt < _RATE_LIMIT_RETRIES:
+            time.sleep(_retry_after_seconds(resp, attempt))
+            continue
+        break
+
+    data = _parse_body(resp)
+    if 200 <= resp.status_code < 300:
+        return json.dumps(data, separators=(",", ":"), ensure_ascii=False)
+    _raise_for_error(resp, "GET", path, data)
+
+
+def _scan_backoff_seconds(resp: requests.Response, attempt: int) -> float:
+    """Patient backoff for the bulk scan: honor Retry-After (clamped to
+    [1, _SCAN_BACKOFF_CAP_S]); otherwise exponential 1,2,4,... capped, plus up
+    to 1 s of jitter to de-sync concurrent workers."""
+    raw = resp.headers.get("Retry-After")
+    wait = None
+    if raw:
+        try:
+            wait = float(raw)
+        except ValueError:
+            wait = None
+    if wait is None:
+        wait = min(2.0 ** attempt, _SCAN_BACKOFF_CAP_S)
+    wait = max(1.0, min(wait, _SCAN_BACKOFF_CAP_S))
+    return wait + random.random()
+
+
+def _post(path: str, body: dict[str, Any]) -> Any:
+    """Authenticated POST against the Viral Loops v3 API, returning the PARSED
+    body (dict/list/None — not a JSON string, since callers aggregate it).
+
+    Retries patiently on 429 (Cloudflare burst limit) and 503 — Viral Loops
+    returns 503 for an offset past the end of the set and occasionally under
+    load (the bulk scanners avoid the past-the-end case by stopping on a short
+    page). See _scan_backoff_seconds for the policy. Raises RuntimeError on
+    other non-2xx.
+    """
+    url = f"{BASE_URL}{path}"
+    resp = None
+    for attempt in range(_SCAN_MAX_RETRIES + 1):
+        resp = _SESSION.post(url, json=body, timeout=60)
+        if resp.status_code in (429, 503) and attempt < _SCAN_MAX_RETRIES:
+            time.sleep(_scan_backoff_seconds(resp, attempt))
+            continue
+        break
+
+    data = _parse_body(resp)
+    if 200 <= resp.status_code < 300:
+        return data
+    _raise_for_error(resp, "POST", path, data)
+
+
+# --- Bulk participant scan (internal, for funnel + export) ----------------
+#
+# /campaign/participant/search is the only paginated bulk endpoint:
+#   POST {"pagination":{"limit":<=100,"offset":N}} -> a flat JSON LIST of rows.
+# It has NO server-side filter, sort or total-count (verified live 2026-06-18 —
+# unknown filter/sort keys are silently ignored), so date/conversion filtering
+# happens client-side here and the only way to count a window is a full scan.
+# The default order is by rank (referralCountTotal desc), stable enough for
+# offset paging. An offset past the end returns HTTP 503 (NOT an empty list),
+# so we stop as soon as a page comes back shorter than the limit.
+SEARCH_PATH = "/campaign/participant/search"
+_SEARCH_PAGE_LIMIT = 100  # API hard cap; larger -> HTTP 400.
+# Safety backstop so a runaway never loops forever. 600 pages * 100 = 60k rows,
+# comfortably above the ~41k campaign size; if we ever hit it we log + stop.
+_MAX_SCAN_PAGES = 600
+# Concurrency for the bulk scan. Viral Loops documents 300/min, but Cloudflare
+# fronts it with a tighter BURST limit that is sensitive to CONCURRENCY, not
+# average rate (measured 2026-06-18: steady ~1 req/s serial never 429s; 8
+# concurrent workers reliably tripped a 429 "Too Many Requests" storm). So keep
+# concurrency low — 3 workers (~3 req/s) is well under 300/min and a gentle
+# burst; the patient exponential backoff in _post (_scan_backoff_seconds) is the
+# safety net for the occasional 429. A full ~412-page scan lands around 3-4 min.
+_SCAN_WORKERS = 3
+
+
+def _search_page(limit: int, offset: int) -> list[dict[str, Any]]:
+    rows = _post(SEARCH_PATH, {"pagination": {"limit": limit, "offset": offset}})
+    if not isinstance(rows, list):
+        raise RuntimeError(
+            f"Unexpected /search response (expected a list): {str(rows)[:200]}"
+        )
+    return rows
+
+
+def _iter_participants(page_limit: int = _SEARCH_PAGE_LIMIT):
+    """Yield every participant row, one page at a time, oldest scan order.
+
+    Pages through /search until a short page (the last one). Caps at
+    _MAX_SCAN_PAGES as a runaway guard. Dedupes by participant id so a row
+    that shifts across a page boundary mid-scan is counted once.
+    """
+    limit = max(1, min(int(page_limit), _SEARCH_PAGE_LIMIT))
+    seen: set[Any] = set()
+    offset = 0
+    for _ in range(_MAX_SCAN_PAGES):
+        rows = _search_page(limit, offset)
+        for r in rows:
+            rid = r.get("id")
+            if rid is not None and rid in seen:
+                continue
+            if rid is not None:
+                seen.add(rid)
+            yield r
+        if len(rows) < limit:
+            return
+        offset += limit
+    logger.warning("participant scan hit _MAX_SCAN_PAGES=%d cap; results truncated", _MAX_SCAN_PAGES)
+
+
+def _campaign_lead_count() -> int | None:
+    """Total participant count from /campaign/stats (leadCount), or None.
+
+    Used purely to size the bulk scan up front so its pages can be fetched
+    concurrently. None -> fall back to a serial scan.
+    """
+    try:
+        data = json.loads(_get(PATHS["stats"]))
+        n = data.get("leadCount") if isinstance(data, dict) else None
+        return int(n) if n is not None else None
+    except Exception:  # never let a stats hiccup block the scan
+        return None
+
+
+def _fetch_page_or_empty(offset: int) -> list[dict[str, Any]]:
+    """A /search page, but a beyond-the-end offset (which Viral Loops answers
+    with HTTP 503) yields [] instead of raising — so buffer pages past the real
+    end of the set don't abort a concurrent scan. Real errors still raise."""
+    try:
+        return _search_page(_SEARCH_PAGE_LIMIT, offset)
+    except RuntimeError as e:
+        if " 503" in str(e):
+            return []
+        raise
+
+
+def _scan_participants(max_pages: int | None = None) -> tuple[list[dict[str, Any]], int, bool]:
+    """Fetch the full participant set. Returns (rows, pages_fetched, truncated).
+
+    When the total is known (leadCount from /campaign/stats) the pages are
+    fetched concurrently (_SCAN_WORKERS at a time); otherwise it falls back to a
+    serial offset walk. Rows are deduped by id. `max_pages` caps the scan for a
+    quick partial estimate — when the cap bites, `truncated` is True.
+    """
+    limit = _SEARCH_PAGE_LIMIT
+    lead = _campaign_lead_count()
+    rows_by_id: dict[Any, dict[str, Any]] = {}
+
+    if lead and lead > 0:
+        # +3 buffer pages cover rows added between the stats read and the scan;
+        # the surplus pages simply 503 -> [] via _fetch_page_or_empty.
+        needed = lead // limit + 3
+        n_pages = min(needed, _MAX_SCAN_PAGES)
+        truncated = needed > _MAX_SCAN_PAGES
+        if max_pages is not None and max_pages > 0 and max_pages < n_pages:
+            n_pages = max_pages
+            truncated = True
+        offsets = [i * limit for i in range(n_pages)]
+        with ThreadPoolExecutor(max_workers=_SCAN_WORKERS) as ex:
+            for page in ex.map(_fetch_page_or_empty, offsets):
+                for r in page:
+                    rid = r.get("id")
+                    rows_by_id[rid if rid is not None else len(rows_by_id)] = r
+        return list(rows_by_id.values()), n_pages, truncated
+
+    # Fallback: total unknown -> serial walk, honoring max_pages.
+    pages = 0
+    truncated = False
+    offset = 0
+    while True:
+        if max_pages is not None and max_pages > 0 and pages >= max_pages:
+            truncated = True
+            break
+        rows = _search_page(limit, offset)
+        pages += 1
+        for r in rows:
+            rid = r.get("id")
+            rows_by_id[rid if rid is not None else len(rows_by_id)] = r
+        if len(rows) < limit:
+            break
+        offset += limit
+        if pages >= _MAX_SCAN_PAGES:
+            truncated = True
+            break
+    return list(rows_by_id.values()), pages, truncated
+
+
+# --- Date-window helpers (client-side; the API has no date filter) --------
+
+
+def _norm_ts(s: str) -> str:
+    """Normalize a date/ISO string to a fixed-width 'YYYY-MM-DDTHH:MM:SS' form
+    for lexicographic comparison. Date-only input is padded to start-of-day.
+    Viral Loops createdAt is UTC ('...Z'), and so is every window bound, so a
+    plain string compare on this form is a correct chronological compare."""
+    s = (s or "").strip().replace(" ", "T")
+    if not s:
+        return ""
+    if len(s) == 10:  # YYYY-MM-DD
+        return s + "T00:00:00"
+    return s[:19]
+
+
+def _in_window(row_ts: str, start_b: str, end_b: str) -> bool:
+    """start inclusive, end exclusive. Empty start/end => unbounded that side."""
+    ts = _norm_ts(row_ts)
+    if start_b and ts < start_b:
+        return False
+    if end_b and ts >= end_b:
+        return False
+    return True
+
+
+def _participant_params(referral_code: str, email: str) -> dict[str, Any]:
+    """Build the participant-identifier query. Viral Loops identifies a
+    participant by `referralCode` and/or `email` — at least one is required
+    (the API rejects the call with "must contain at least one of
+    [email, referralCode]" otherwise). Both are passed when given."""
+    if not referral_code and not email:
+        raise ValueError(
+            "Provide at least one of referral_code or email to identify the participant."
+        )
+    return {"referralCode": referral_code, "email": email}
+
+
+# --- Export file store (TTL, in-memory) -----------------------------------
+#
+# Mirrors the DHL label store: export_participants writes a CSV/JSON to this
+# in-process store under an unguessable token and returns a short download_url
+# instead of inlining tens of thousands of rows (which would overrun claude.ai's
+# tool-result ceiling). The gateway proxies /dl/viral-loops/<token> -> this
+# container's GET /download/<token>; the ~192-bit token is the capability.
+# In-memory only: a container restart drops all links (exports are ephemeral —
+# regenerate). Accessed from sync tool calls (anyio worker thread) and the async
+# /download route, so guard with a plain Lock.
+VIRAL_LOOPS_DOWNLOAD_BASE_URL = (
+    os.environ.get("VIRAL_LOOPS_DOWNLOAD_BASE_URL")
+    or "https://mcp.choiz.com.mx/dl/viral-loops"
+).rstrip("/")
+try:
+    EXPORT_TTL_MINUTES = int(os.environ.get("VIRAL_LOOPS_EXPORT_TTL_MINUTES") or "30")
+except ValueError:
+    EXPORT_TTL_MINUTES = 30
+# Cap stored exports so a burst can't grow the container unbounded. A full ~41k
+# CSV is a few MB; 10 * a few MB stays well under the 256m container cap.
+_MAX_EXPORTS = 10
+
+_export_lock = threading.Lock()
+_export_store: dict[str, dict[str, Any]] = {}
+
+
+def _store_export(data: bytes, filename: str, content_type: str) -> str:
+    """Stash an export under a fresh unguessable token. Returns the token."""
+    token = secrets.token_urlsafe(24)  # ~192 bits
+    now = time.time()
+    with _export_lock:
+        for t in [t for t, e in _export_store.items() if e["expires_at"] <= now]:
+            _export_store.pop(t, None)
+        if len(_export_store) >= _MAX_EXPORTS:
+            for t in sorted(_export_store, key=lambda t: _export_store[t]["expires_at"])[
+                : len(_export_store) - _MAX_EXPORTS + 1
+            ]:
+                _export_store.pop(t, None)
+        _export_store[token] = {
+            "data": data,
+            "filename": filename,
+            "content_type": content_type,
+            "expires_at": now + EXPORT_TTL_MINUTES * 60,
+        }
+    return token
+
+
+def _get_export(token: str) -> dict[str, Any] | None:
+    """Return a non-expired stored export, or None (dropping it if expired)."""
+    now = time.time()
+    with _export_lock:
+        entry = _export_store.get(token)
+        if entry is None:
+            return None
+        if entry["expires_at"] <= now:
+            _export_store.pop(token, None)
+            return None
+        return entry
+
+
+# Columns emitted for a CSV export — a useful analyst subset of the flat
+# /search row (the JSON export keeps every field).
+_EXPORT_COLUMNS = [
+    "id", "email", "firstname", "lastname", "referralCode", "createdAt",
+    "referrerId", "referrerEmail", "referrerReferralCode",
+    "referralCountTotal", "conversionCountTotal", "converted",
+    "acquiredFrom", "fraudLevel", "risk", "rank",
+]
+
+
+# --- MCP server -----------------------------------------------------------
+
+# host="0.0.0.0" so the gateway reaches us across the docker bridge.
+# streamable_http_path="/" so the gateway can strip /mcp/viral-loops and forward to "/".
+# stateless_http=True: ephemeral sessions, sidesteps stale-session-after-redeploy.
+mcp = FastMCP(
+    name="viral-loops",
+    host="0.0.0.0",
+    port=8080,
+    streamable_http_path="/",
+    stateless_http=True,
+)
+
+
+@mcp.custom_route("/download/{token}", methods=["GET"])
+async def download_export(request: Request) -> Response:
+    """Serve a stored export (CSV/JSON) by token as a browser download.
+
+    Reached publicly (no MCP bearer) via the gateway + Worker:
+    https://mcp.choiz.com.mx/dl/viral-loops/<token> -> gateway /dl/viral-loops
+    -> here. The token is the capability; unknown/expired -> 404.
+    """
+    entry = _get_export(request.path_params.get("token", ""))
+    if entry is None:
+        return Response("Export not found or expired.", status_code=404, media_type="text/plain")
+    return Response(
+        content=entry["data"],
+        media_type=entry["content_type"],
+        headers={"Content-Disposition": f'attachment; filename="{entry["filename"]}"'},
+    )
+
+
+@mcp.tool()
+def get_campaign() -> str:
+    """Get the public configuration/info of the Viral Loops campaign.
+
+    The campaign is determined by the server's API token — there is no campaign
+    id to pass. Read-only. Calls GET /campaign/data.
+    """
+    return _get(PATHS["campaign"])
+
+
+@mcp.tool()
+def get_campaign_stats() -> str:
+    """Get headline campaign stats: leadCount, referralCountTotal,
+    conversionCountTotal.
+
+    The single best "how is the referral program doing overall" call. Read-only.
+    Calls GET /campaign/stats.
+    """
+    return _get(PATHS["stats"])
+
+
+@mcp.tool()
+def get_participant(referral_code: str = "", email: str = "") -> str:
+    """Fetch one participant's data (referral code, rank, referral counts, state).
+
+    Identify the participant by `referral_code` and/or `email` — at least one is
+    required. Read-only. Calls GET /campaign/participant/data.
+    """
+    return _get(PATHS["participant"], _participant_params(referral_code, email))
+
+
+@mcp.tool()
+def get_participant_referrals(
+    referral_code: str = "", email: str = "", page: int = 1, count: int = 10
+) -> str:
+    """List the people a given participant referred.
+
+    Identify the referrer by `referral_code` and/or `email` (at least one
+    required). `page` is 1-based; `count` is the page size — kept small
+    (default 10) because claude.ai rejects large tool results. `count` is
+    clamped to [1, 25] and `page` to >=1 (the ceiling keeps the result under
+    claude.ai's ~2-3 KB tool-result limit). Read-only.
+    Calls GET /campaign/participant/referrals.
+    """
+    params = _participant_params(referral_code, email)
+    page = max(1, int(page))
+    count = min(max(1, int(count)), _MAX_REFERRALS_COUNT)
+    # This endpoint paginates by limit/offset; page/count are SILENTLY IGNORED
+    # (verified live 2026-06-18 — count=5 still returned 50 rows, but limit=5
+    # returned 5). Map the friendly page/count interface onto limit/offset so
+    # the clamp actually bounds the payload and paging works.
+    params.update({"limit": count, "offset": (page - 1) * count})
+    return _get(PATHS["referrals"], params)
+
+
+@mcp.tool()
+def get_participant_rank(referral_code: str = "", email: str = "") -> str:
+    """Get a participant's leaderboard / waitlist rank.
+
+    Identify by `referral_code` and/or `email` (at least one required). Read-only.
+    Calls GET /campaign/participant/rank.
+    """
+    return _get(PATHS["rank"], _participant_params(referral_code, email))
+
+
+@mcp.tool()
+def get_participant_order(referral_code: str = "", email: str = "") -> str:
+    """Get the order/position in which a participant joined the campaign.
+
+    Identify by `referral_code` and/or `email` (at least one required). Read-only.
+    Calls GET /campaign/participant/order.
+    """
+    return _get(PATHS["order"], _participant_params(referral_code, email))
+
+
+@mcp.tool()
+def get_participant_referrer(referral_code: str = "", email: str = "") -> str:
+    """Get the referrer of a participant (who invited them).
+
+    Identify by `referral_code` and/or `email` (at least one required). Read-only.
+    Calls GET /campaign/participant/referrer.
+    """
+    return _get(PATHS["referrer"], _participant_params(referral_code, email))
+
+
+@mcp.tool()
+def get_participant_rewards(
+    referral_code: str = "", email: str = "", status: str = "given"
+) -> str:
+    """Get one participant's rewards. `status` is "given" (distributed) or
+    "pending" (earned but not yet redeemed).
+
+    Identify by `referral_code` and/or `email` (at least one required). An
+    identifier is mandatory on purpose: without one the endpoint returns the
+    WHOLE campaign's rewards (thousands of entries), which overruns claude.ai's
+    tool-result limit. Read-only.
+    Calls GET /campaign/participant/rewards/{given|pending}.
+    """
+    s = status.strip().lower()
+    if s not in ("given", "pending"):
+        raise ValueError('status must be "given" or "pending"')
+    key = "rewards_pending" if s == "pending" else "rewards_given"
+    return _get(PATHS[key], _participant_params(referral_code, email))
+
+
+# --- Funnel + export (bulk aggregation over /search) ----------------------
+
+
+def _is_referred(row: dict[str, Any]) -> bool:
+    return bool(row.get("referrerId")) or bool(row.get("referrerReferralCode"))
+
+
+def _is_converted(row: dict[str, Any]) -> bool:
+    return row.get("converted") == 1 or row.get("converted") is True
+
+
+def _rate(num: int, den: int) -> float | None:
+    return round(num / den, 4) if den else None
+
+
+def _tally(rows: list[dict[str, Any]]) -> tuple[int, int, int, int]:
+    """(leads, referrers_with_link, referred_leads, conversions) for `rows`."""
+    leads = referrers = referred = conversions = 0
+    for r in rows:
+        leads += 1
+        if (r.get("referralCountTotal") or 0) > 0:
+            referrers += 1
+        if _is_referred(r):
+            referred += 1
+            if _is_converted(r):
+                conversions += 1
+    return leads, referrers, referred, conversions
+
+
+def _funnel_block(counts: tuple[int, int, int, int]) -> dict[str, Any]:
+    leads, referrers, referred, conversions = counts
+    return {
+        "leads": leads,
+        "referrers_with_link": referrers,
+        "referred_leads": referred,
+        "conversions": conversions,
+        "rates": {
+            "lead_to_referrer": _rate(referrers, leads),
+            "referrer_to_referred": _rate(referred, referrers),
+            "referred_to_conversion": _rate(conversions, referred),
+        },
+    }
+
+
+@mcp.tool()
+def get_referral_funnel(
+    start: str = "", end: str = "", group_by: str = "", max_pages: int = 0
+) -> str:
+    """End-to-end referral funnel for a date window — small summary, NOT rows.
+
+    Returns the Viral-Loops-owned funnel steps over participants who JOINED in
+    the window [start, end):
+      • leads               — all participants (each gets a referral link on join)
+      • referrers_with_link — participants who actually referred ≥1 person
+      • referred_leads      — participants who arrived via someone's referral link
+      • conversions         — referred leads who paid (converted)
+    plus rates: lead_to_referrer, referrer_to_referred (referred per referrer),
+    referred_to_conversion. (Reconciled with /campaign/stats on 2026-06-18.)
+
+    `start`/`end` are dates ("YYYY-MM-DD") or ISO timestamps, UTC; start is
+    inclusive, end exclusive; leave either blank for unbounded that side.
+    `group_by="month"` adds a per-join-month breakdown — keep the window narrow
+    or that object can exceed claude.ai's result limit.
+
+    HOW IT WORKS / COST: the Viral Loops API has NO server-side date filter, sort
+    or count, so this does a FULL campaign scan every call (~41k participants,
+    paged 100 at a time, fetched concurrently) — roughly 3-5 minutes. A date
+    window does NOT make it cheaper. `max_pages` (0 = all) caps the scan for a
+    quick partial estimate; the result then carries scan.truncated=true. Counts
+    are computed server-side; only this small summary crosses the tool channel.
+    Read-only.
+    """
+    start_b, end_b = _norm_ts(start), _norm_ts(end)
+    rows, pages, truncated = _scan_participants(max_pages or None)
+    windowed = [r for r in rows if _in_window(r.get("createdAt", ""), start_b, end_b)]
+
+    out: dict[str, Any] = {"window": {"start": start or None, "end": end or None}}
+    out.update(_funnel_block(_tally(windowed)))
+
+    if group_by.strip().lower() in ("month", "months"):
+        buckets: dict[str, list[dict[str, Any]]] = {}
+        for r in windowed:
+            buckets.setdefault((r.get("createdAt") or "")[:7], []).append(r)
+        months: dict[str, Any] = {}
+        for m in sorted(buckets):
+            if not m:
+                continue
+            leads, referrers, referred, conversions = _tally(buckets[m])
+            months[m] = {
+                "leads": leads,
+                "referrers_with_link": referrers,
+                "referred_leads": referred,
+                "conversions": conversions,
+                "referred_to_conversion": _rate(conversions, referred),
+            }
+        out["months"] = months
+
+    out["scan"] = {
+        "participants_scanned": len(rows),
+        "pages": pages,
+        "truncated": truncated,
+    }
+    return json.dumps(out, separators=(",", ":"), ensure_ascii=False)
+
+
+@mcp.tool()
+def export_participants(
+    start: str = "",
+    end: str = "",
+    fmt: str = "csv",
+    referred_only: bool = False,
+    converted_only: bool = False,
+    max_pages: int = 0,
+) -> str:
+    """Export the full filtered participant set to a downloadable file; returns a
+    short link, NOT the rows (so it never floods the tool channel).
+
+    Scans the whole campaign, filters by JOIN-date window [start, end) (dates or
+    ISO, UTC; start inclusive, end exclusive; blank = unbounded), optionally to
+    `referred_only` (arrived via a referral) or `converted_only` (referred AND
+    paid), serializes to `fmt` ("csv" — an analyst column subset — or "json" —
+    every field), and stores it under a one-time token. Returns:
+      {"download_url","rows","format","expires_in_minutes","window","scan"}.
+
+    CONSUMPTION CAVEAT: in claude.ai the analysis sandbox has NO outbound
+    network, so Claude CANNOT fetch this URL itself — give it to the user to
+    open in a browser (or have them re-upload the file to Claude as an
+    attachment to analyze). In Claude Code the agent can curl it directly. The
+    link expires after expires_in_minutes and dies on container restart.
+
+    COST: same full-scan as get_referral_funnel (~3-5 min; the API offers no
+    server-side filter/count). `max_pages` (0 = all) caps the scan; the result
+    then carries scan.truncated=true. Read-only.
+    """
+    f = fmt.strip().lower()
+    if f not in ("csv", "json"):
+        raise ValueError('fmt must be "csv" or "json"')
+
+    start_b, end_b = _norm_ts(start), _norm_ts(end)
+    rows, pages, truncated = _scan_participants(max_pages or None)
+    selected = []
+    for r in rows:
+        if not _in_window(r.get("createdAt", ""), start_b, end_b):
+            continue
+        if converted_only and not (_is_referred(r) and _is_converted(r)):
+            continue
+        if referred_only and not _is_referred(r):
+            continue
+        selected.append(r)
+
+    if f == "csv":
+        buf = io.StringIO()
+        writer = csv.DictWriter(buf, fieldnames=_EXPORT_COLUMNS, extrasaction="ignore")
+        writer.writeheader()
+        for r in selected:
+            writer.writerow({k: r.get(k) for k in _EXPORT_COLUMNS})
+        # utf-8-sig: a BOM so Excel reads accented names as UTF-8, not mojibake.
+        data = buf.getvalue().encode("utf-8-sig")
+        content_type = "text/csv; charset=utf-8"
+        ext = "csv"
+    else:
+        data = json.dumps(selected, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        content_type = "application/json"
+        ext = "json"
+
+    label = (start or "all").replace(":", "").replace(" ", "_")
+    if end:
+        label += "_to_" + end.replace(":", "").replace(" ", "_")
+    filename = f"viral-loops-participants_{label}.{ext}"
+    token = _store_export(data, filename, content_type)
+
+    return json.dumps(
+        {
+            "download_url": f"{VIRAL_LOOPS_DOWNLOAD_BASE_URL}/{token}",
+            "rows": len(selected),
+            "format": f,
+            "bytes": len(data),
+            "expires_in_minutes": EXPORT_TTL_MINUTES,
+            "window": {"start": start or None, "end": end or None},
+            "scan": {"participants_scanned": len(rows), "pages": pages, "truncated": truncated},
+            "note": "Give this link to the user to open in a browser — claude.ai's "
+                    "sandbox cannot fetch it. In Claude Code you can curl it directly.",
+        },
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+
+
+def main() -> None:
+    logger.info("viral-loops mcp starting — base=%s", BASE_URL)
+    mcp.run(transport="streamable-http")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a read-only Viral Loops MCP container behind the gateway, plus the two bulk-aggregation tools needed for the referral-program funnel question.

## What deploys
- **viral-loops** image (new container) — 10 read-only tools.
- **gateway** image (rebuilt) — adds the public `/dl/viral-loops/<token>` export-download proxy.
- (compose.yml change → CI rebuilds all images per the existing design.)

## Tools
- `get_referral_funnel(start, end, group_by, max_pages)` — leads → referrers_with_link → referred_leads → conversions + rates over a join-date window; small summary, not rows. Field mapping reconciled live against `/campaign/stats` (leads 40959≈40958, referred 4605≈4606, conversions 1539≈1540).
- `export_participants(...)` — full filtered set to CSV/JSON in an in-memory TTL store; returns a short download link (DHL externalization pattern).
- Plus 8 per-participant GET tools.

## Review fixes on existing tools
- `get_participant_rewards`: reject `status` not in {given, pending}.
- `get_participant_referrals`: paginate by the real `limit`/`offset` (the API silently ignored `page`/`count`); clamp page size ≤25.
- `_get`: 429 retry/backoff; empty 2xx body → `null`.

## Notes
- `/search` is the only bulk endpoint (limit≤100/offset, no server-side filter/sort/count), so date windows are applied client-side over a full ~412-page scan (low concurrency under Cloudflare's burst limit + patient 429 backoff; ~3-4 min).
- EC2 `.env` already has `VIRAL_LOOPS_API_TOKEN` (verified). New export env vars have compose defaults.

## Validation
`py_compile` ✓, `tsc --noEmit` exit 0 ✓, `docker compose config` exit 0 ✓, live docker MCP test (tools/list, funnel reconciliation, export+download+404, status error, null handling, referrals clamp+pagination) ✓.