### PR TITLE
Deploy Mixpanel remote-proxy MCP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -109,6 +109,32 @@ KAPSO_API_KEY_CHOIZ_SUPPORT=
 KAPSO_API_KEY_TIMELESS_SALES=
 KAPSO_API_KEY_TIMELESS_SUPPORT=
 
+# --- Mixpanel MCP (remote, single tenant) ---
+#
+# Mixpanel serves an official Streamable HTTP MCP at
+# https://mcp.mixpanel.com/mcp. We proxy it through the gateway so claude.ai
+# never sees the credential and the URL is branded under
+# mcp.choiz.com.mx/mcp/mixpanel/. No container, no Dockerfile, no CI build job
+# — only these two env vars + the route entry in gateway/src/index.ts.
+#
+# Auth = a Mixpanel SERVICE ACCOUNT. Mixpanel's hosted MCP expects the (unusual)
+# header `Authorization: Bearer Basic <base64(username:secret)>`. The gateway
+# builds that header itself from the two vars below (see resolveRemoteAuthValue
+# in gateway/src/index.ts) — you do NOT pre-encode anything. Both must be set or
+# the route is skipped.
+#
+# How to obtain (verified 2026-06-18):
+#   Mixpanel → Organization Settings → Service Accounts → create one. Copy:
+#     - the USERNAME, e.g. my-sa.abc123.mp-service-account  -> MIXPANEL_API_KEY
+#     - the SECRET shown once at creation                   -> MIXPANEL_API_SECRET
+#   The SA must have access to the target project. NOTE: a Project Token or the
+#   legacy Project API Secret (32-char hex) will NOT work here — it must be a
+#   service account (username ends in `.mp-service-account`). If the project is
+#   on EU/India data residency, raise it — a region tweak may be needed.
+# Rotate by regenerating the SA secret and updating MIXPANEL_API_SECRET only.
+MIXPANEL_API_KEY=
+MIXPANEL_API_SECRET=
+
 # --- GSC MCP (multi-tenant: choiz + timeless) ---
 #
 # GSC reuses GA4_SERVICE_ACCOUNT_JSON_B64 above (same Choiz reader

--- a/compose.yml
+++ b/compose.yml
@@ -59,6 +59,14 @@ services:
       KAPSO_API_KEY_CHOIZ_SUPPORT:    ${KAPSO_API_KEY_CHOIZ_SUPPORT:-}
       KAPSO_API_KEY_TIMELESS_SALES:   ${KAPSO_API_KEY_TIMELESS_SALES:-}
       KAPSO_API_KEY_TIMELESS_SUPPORT: ${KAPSO_API_KEY_TIMELESS_SUPPORT:-}
+      # Mixpanel remote MCP (https://mcp.mixpanel.com/mcp). Service-account auth:
+      # the gateway builds `Authorization: Bearer Basic <base64(user:secret)>`
+      # from these two vars (see resolveRemoteAuthValue in gateway/src/index.ts).
+      # KEY = SA username (…mp-service-account); SECRET = its secret. Both must
+      # be set for the route to register (default-empty so a missing pair just
+      # skips the route instead of failing the stack).
+      MIXPANEL_API_KEY:               ${MIXPANEL_API_KEY:-}
+      MIXPANEL_API_SECRET:            ${MIXPANEL_API_SECRET:-}
       # Re-enabled 2026-05-07: cutover to the official googleads/google-ads-mcp
       # eliminates supergateway --stateless, so the original tunnel-zombie
       # trigger (per-request gRPC channel storm to googleads.googleapis.com)

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -66,8 +66,28 @@ const upstreams: Record<string, string | undefined> = {
 // no compose service, no CI build job.
 interface RemoteUpstream {
   target: string;       // https URL the proxy forwards to (origin + base path)
-  apiKeyEnv: string;    // env var holding the upstream API key
   apiKeyHeader: string; // header name to set on the outgoing request
+  // Credential source — provide exactly ONE of:
+  apiKeyEnv?: string;   // (a) env var whose value is used as the header verbatim
+  // (b) build a Basic-style credential from a username + secret pair:
+  basicUserEnv?: string;   //     env var holding the username
+  basicSecretEnv?: string; //     env var holding the secret
+  valuePrefix?: string;    //     header value = `${valuePrefix}${base64(user:secret)}`
+}
+
+// Resolve the outgoing auth header VALUE for a remote upstream, or undefined if
+// its credential env var(s) are not set (route is then skipped). Supports both
+// the verbatim single-env case (kapso) and the username+secret Basic build
+// (Mixpanel) without baking a pre-formatted blob into .env.
+function resolveRemoteAuthValue(cfg: RemoteUpstream): string | undefined {
+  if (cfg.apiKeyEnv) return process.env[cfg.apiKeyEnv] || undefined;
+  if (cfg.basicUserEnv && cfg.basicSecretEnv) {
+    const user = process.env[cfg.basicUserEnv];
+    const secret = process.env[cfg.basicSecretEnv];
+    if (!user || !secret) return undefined;
+    return (cfg.valuePrefix ?? "") + Buffer.from(`${user}:${secret}`).toString("base64");
+  }
+  return undefined;
 }
 const remoteUpstreams: Record<string, RemoteUpstream> = {
   // Kapso is project-scoped: one API key = one project. We expose one slug
@@ -93,6 +113,21 @@ const remoteUpstreams: Record<string, RemoteUpstream> = {
     apiKeyEnv: "KAPSO_API_KEY_TIMELESS_SUPPORT",
     apiKeyHeader: "x-api-key",
   },
+  // Mixpanel hosts an official Streamable HTTP MCP. Headless auth is a service
+  // account sent as the (unusual) literal header
+  // `Authorization: Bearer Basic <base64(username:secret)>` — note the
+  // "Bearer Basic " prefix (verified against the live API 2026-06-18). We keep
+  // the SA username + secret as two readable env vars and build that value here
+  // (see resolveRemoteAuthValue), so rotating the secret is a one-value change.
+  // MIXPANEL_API_KEY = SA username (…mp-service-account); MIXPANEL_API_SECRET =
+  // its secret. Single project/tenant; no per-brand split.
+  "/mcp/mixpanel": {
+    target: "https://mcp.mixpanel.com/mcp",
+    apiKeyHeader: "authorization",
+    basicUserEnv: "MIXPANEL_API_KEY",
+    basicSecretEnv: "MIXPANEL_API_SECRET",
+    valuePrefix: "Bearer Basic ",
+  },
 };
 
 // --- Health check (no auth) ---
@@ -102,7 +137,7 @@ app.get("/healthz", (_req, res) => {
     routes: [
       ...Object.keys(upstreams).filter((k) => upstreams[k]),
       ...Object.keys(remoteUpstreams).filter(
-        (k) => process.env[remoteUpstreams[k].apiKeyEnv],
+        (k) => resolveRemoteAuthValue(remoteUpstreams[k]),
       ),
     ],
   });
@@ -191,9 +226,10 @@ for (const [prefix, target] of Object.entries(upstreams)) {
 
 // --- Wire remote-proxied MCPs (HTTP→HTTPS with API-key injection) ---
 for (const [prefix, cfg] of Object.entries(remoteUpstreams)) {
-  const apiKey = process.env[cfg.apiKeyEnv];
+  const apiKey = resolveRemoteAuthValue(cfg);
   if (!apiKey) {
-    console.warn(`[mcp-gateway] skipping remote ${prefix}: ${cfg.apiKeyEnv} not set`);
+    const envNames = cfg.apiKeyEnv ?? `${cfg.basicUserEnv}+${cfg.basicSecretEnv}`;
+    console.warn(`[mcp-gateway] skipping remote ${prefix}: ${envNames} not set`);
     continue;
   }
   app.use(
@@ -319,6 +355,6 @@ app.listen(port, "0.0.0.0", () => {
   console.log(`[mcp-gateway] container routes:`, Object.keys(upstreams).filter((k) => upstreams[k]));
   console.log(
     `[mcp-gateway] remote routes:`,
-    Object.keys(remoteUpstreams).filter((k) => process.env[remoteUpstreams[k].apiKeyEnv]),
+    Object.keys(remoteUpstreams).filter((k) => resolveRemoteAuthValue(remoteUpstreams[k])),
   );
 });


### PR DESCRIPTION
Brings the Mixpanel remote-proxy MCP (originally on `feat/mixpanel-mcp`, commit e0907f5) onto `master` so it deploys. Cherry-picked cleanly onto the post-viral-loops master (no conflicts).

## What it adds
- Gateway route `/mcp/mixpanel` → proxies to Mixpanel's hosted MCP (`mcp.mixpanel.com/mcp`), injecting `Authorization: Bearer Basic <base64(user:secret)>` built from `MIXPANEL_API_KEY` + `MIXPANEL_API_SECRET` (service account). Generalizes the remote-upstream resolver (`resolveRemoteAuthValue`) to support the username+secret Basic build alongside the existing verbatim-key case (kapso).
- compose.yml + .env.example: the two `MIXPANEL_*` env vars (default-empty; route is skipped if unset).
- No container, no Dockerfile, no CI build job (remote proxy). No Worker change (`/mcp/*` is forwarded generically).

## Prereqs (verified)
- `MIXPANEL_API_KEY` + `MIXPANEL_API_SECRET` are already present in the EC2 `.env`, so the route will register on deploy.

## Validation
`tsc --noEmit` exit 0 ✓, `docker compose config` exit 0 ✓ (gateway receives both MIXPANEL envs). Merged `index.ts` retains all routes (mixpanel, viral-loops, /dl/dhl, /dl/viral-loops) and the remote loop uses the generalized resolver.