### PR TITLE
ops: worker secret resilience (1-click restore + OAuth-layer monitor)

### DIFF
--- a/.github/workflows/bootstrap-worker-secrets.yml
+++ b/.github/workflows/bootstrap-worker-secrets.yml
@@ -1,0 +1,79 @@
+name: Bootstrap worker secrets
+
+# One-click RESTORE of the Cloudflare Worker's secrets from GitHub Actions
+# Secrets (the encrypted, version-controlled source of truth). Run this whenever
+# the Worker comes up empty — e.g. it was deleted/recreated and a plain
+# `wrangler deploy` brought back the code + route + KV binding but NOT the
+# secrets (secrets are never stored in the repo). See the incident writeup:
+# memory project_worker_route_detach_2026-06-26.
+#
+# Required GitHub Actions secrets
+# (repo -> Settings -> Secrets and variables -> Actions):
+#   CLOUDFLARE_API_TOKEN   already set (Workers Scripts:Edit on the zone)
+#   GOOGLE_CLIENT_ID       OAuth client id, GCP project "MCPs" / Vaultwarden
+#   GOOGLE_CLIENT_SECRET   same OAuth client
+#   WORKER_SHARED_SECRET   MUST equal ~/choiz-mcp-gateway/.env on the EC2
+#   DASHBOARD_API_KEY      MUST equal the Vercel project's WAREHOUSE_API_KEY
+#
+# Secret VALUES are piped to wrangler over stdin and are masked by GitHub in
+# logs; they never appear in workflow inputs.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # Share the deploy-worker group so a bootstrap and a deploy can't race.
+  group: deploy-worker
+  cancel-in-progress: false
+
+jobs:
+  bootstrap:
+    name: deploy + wrangler secret put x4
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: worker
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: worker/package-lock.json
+      - run: npm ci
+
+      # Deploy FIRST so the script (and its route) exist. `wrangler secret put`
+      # requires the Worker script to already exist; if the Worker had been
+      # deleted, this recreates it before we attach secrets.
+      - name: Deploy worker (ensure script + route)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: npx wrangler deploy
+
+      - name: Put the 4 secrets (from GitHub Secrets, via stdin)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          WORKER_SHARED_SECRET: ${{ secrets.WORKER_SHARED_SECRET }}
+          DASHBOARD_API_KEY: ${{ secrets.DASHBOARD_API_KEY }}
+        run: |
+          set -euo pipefail
+          put() {
+            name="$1"; val="$2"
+            if [ -z "$val" ]; then
+              echo "::error::$name is empty in GitHub Secrets — add it before running this workflow"
+              exit 1
+            fi
+            # printf (no trailing newline) | wrangler secret put <name>
+            printf '%s' "$val" | npx wrangler secret put "$name"
+            echo "✓ set $name"
+          }
+          put GOOGLE_CLIENT_ID     "$GOOGLE_CLIENT_ID"
+          put GOOGLE_CLIENT_SECRET "$GOOGLE_CLIENT_SECRET"
+          put WORKER_SHARED_SECRET "$WORKER_SHARED_SECRET"
+          put DASHBOARD_API_KEY    "$DASHBOARD_API_KEY"
+          echo "All 4 secrets restored. (secrets apply live; no extra deploy needed)"

--- a/.github/workflows/monitor-worker.yml
+++ b/.github/workflows/monitor-worker.yml
@@ -1,0 +1,133 @@
+name: Monitor worker OAuth layer
+
+# Synthetic check of the Cloudflare Worker's PUBLIC OAuth/MCP surface — the
+# layer the tunnel monitor does NOT cover. The tunnel monitor only probes
+# tunnel.choiz.com.mx/healthz (the gateway behind the tunnel); it stays green
+# even when the Worker is gone, because traffic then falls straight through to
+# the Express gateway. That exact blind spot caused the 2026-06-26 outage
+# (Worker deleted -> recreated empty -> every connector failed). See memory
+# project_worker_route_detach_2026-06-26.
+#
+# This catches three independent failure modes, each from a single HTTP probe:
+#   1. Worker not intercepting the route (deleted / route detached)
+#        -> /.well-known is served by Express (X-Powered-By header) or != 200
+#   2. GOOGLE_CLIENT_ID secret missing
+#        -> /authorize redirects to Google with client_id=undefined
+#   3. DASHBOARD_API_KEY secret missing
+#        -> /api/warehouse/query returns 503 (endpoint_not_configured)
+#
+# On failure it opens (or reuses) a GitHub issue, which emails the team. It does
+# NOT auto-remediate: the fix is to run the "Bootstrap worker secrets" workflow.
+#
+# Cadence: every 15 min (lighter than the 5-min tunnel monitor) — check #2
+# registers one throwaway DCR client per run, so we keep the volume modest.
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: monitor-worker
+  cancel-in-progress: false
+
+jobs:
+  probe:
+    name: Probe OAuth + DCR + dashboard surface
+    runs-on: ubuntu-latest
+    steps:
+      - name: Probe
+        id: probe
+        run: |
+          set -uo pipefail
+          base="https://mcp.choiz.com.mx"
+          fail=""
+
+          # 1) OAuth metadata: must be 200 JSON, served by Cloudflare (the Worker),
+          #    NOT by the Express gateway (which means the Worker was bypassed).
+          hdrs=$(curl -s -m 10 -D - -o /tmp/meta.json "$base/.well-known/oauth-authorization-server")
+          code=$(printf '%s' "$hdrs" | awk 'NR==1{print $2}')
+          if printf '%s' "$hdrs" | grep -qi '^x-powered-by:[[:space:]]*express'; then
+            fail="$fail
+          - /.well-known is served by Express -> the Worker is NOT intercepting mcp.choiz.com.mx/* (deleted or route detached)"
+          elif [ "$code" != "200" ] || ! grep -q 'registration_endpoint' /tmp/meta.json; then
+            fail="$fail
+          - /.well-known/oauth-authorization-server unhealthy (HTTP ${code:-000})"
+          fi
+
+          # 2) GOOGLE_CLIENT_ID present: register a throwaway DCR client, then
+          #    drive /authorize and inspect the redirect to Google.
+          cid=$(curl -s -m 10 -X POST "$base/register" -H 'content-type: application/json' \
+            -d '{"client_name":"healthcheck","redirect_uris":["https://claude.ai/api/mcp/auth_callback"],"token_endpoint_auth_method":"none","grant_types":["authorization_code"],"response_types":["code"]}' \
+            | sed -n 's/.*"client_id":"\([^"]*\)".*/\1/p')
+          if [ -z "$cid" ]; then
+            fail="$fail
+          - DCR /register did not return a client_id"
+          else
+            loc=$(curl -s -m 10 -o /dev/null -D - \
+              "$base/authorize?response_type=code&client_id=$cid&redirect_uri=https%3A%2F%2Fclaude.ai%2Fapi%2Fmcp%2Fauth_callback&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256&state=hc" \
+              | grep -i '^location:')
+            if printf '%s' "$loc" | grep -q 'client_id=undefined'; then
+              fail="$fail
+          - /authorize sends client_id=undefined -> GOOGLE_CLIENT_ID secret missing on the Worker"
+            fi
+          fi
+
+          # 3) DASHBOARD_API_KEY present: a dummy bearer should be 401 (key set),
+          #    NOT 503 (key missing / endpoint not configured).
+          dash=$(curl -s -m 10 -o /dev/null -w '%{http_code}' -X POST "$base/api/warehouse/query" \
+            -H 'authorization: Bearer healthcheck' -H 'content-type: application/json' -d '{}')
+          if [ "$dash" = "503" ]; then
+            fail="$fail
+          - /api/warehouse/query returns 503 -> DASHBOARD_API_KEY secret missing on the Worker"
+          fi
+
+          if [ -n "$fail" ]; then
+            echo "Worker OAuth layer UNHEALTHY:$fail"
+            {
+              echo "failed=true"
+              echo "detail<<DETAIL_EOF"
+              printf '%s\n' "$fail"
+              echo "DETAIL_EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "Worker OAuth layer healthy at $(date -u +%H:%M:%SZ)"
+            echo "failed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open issue on failure (dedup by title)
+        if: steps.probe.outputs.failed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          existing=$(gh issue list --repo "${{ github.repository }}" --state open \
+            --search 'Worker OAuth layer unhealthy in:title' --json number --jq 'length')
+          if [ "$existing" != "0" ]; then
+            echo "An open 'Worker OAuth layer unhealthy' issue already exists; not opening another."
+            exit 0
+          fi
+          BODY="Auto-monitor detected the Cloudflare Worker's OAuth/MCP surface is unhealthy.
+          Claude.ai connectors will fail at sign-in/registration or on tool calls.
+
+          ## Failed checks
+          ${{ steps.probe.outputs.detail }}
+
+          ## Likely cause
+          The Worker lost its secrets, or its route (mcp.choiz.com.mx/*) detached / the
+          Worker was deleted. Background: memory project_worker_route_detach_2026-06-26.
+
+          ## Fix
+          Run the **Bootstrap worker secrets** workflow (restores all 4 secrets from
+          GitHub Secrets and redeploys). If only the route is gone, a plain
+          \`deploy-worker\` redeploy re-asserts it.
+
+          - Run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          gh issue create --repo "${{ github.repository }}" \
+            --title "[ops] Worker OAuth layer unhealthy at $(date -u +%H:%MZ)" \
+            --body "$BODY" \
+            --label "ops"

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -112,6 +112,7 @@ Not blocking, but worth doing eventually:
 - **Slim down the EC2 repo clone**: now that CI/CD pushes `compose.yml` via SSM, the rest of the repo on EC2 (`gateway/`, `mcp/`, `docs/`, etc.) is unused at runtime. Could be pruned to just `compose.yml` + `.env` for clarity.
 - **Image rollback ergonomics**: `:latest` is convenient but rollbacks require knowing the old SHA. Could add a small script that lists recent SHAs in GHCR and pins one in `.env` via `IMAGE_TAG`.
 - **Secondary maintainer**: document who the backup maintainer is so this doesn't single-thread on one person.
+- **Cloudflare blast-radius hardening** (opened 2026-06-26 after the worker-wipe outage): the `CLOUDFLARE_API_TOKEN` used by CI has `Workers Scripts:Edit`, which can also **delete** the Worker — a single leaked/misused token (or dashboard access) can take down every connector, as happened on 2026-06-26 (Worker deleted manually, no GH/CI trace; cause never attributed). To do: (a) review who has Cloudflare account access and which API tokens exist + their scopes; (b) consider splitting a tighter deploy token (or Workers "deploy-only" where possible); (c) document in `OPERATIONS.md` that the master copy of every Worker secret lives in **GitHub Actions Secrets + Vaultwarden** (Cloudflare and Vercel "Sensitive" vars are NOT readable back). See `project_worker_route_detach_2026-06-26` memory.
 
 ### 4. Known pending decisions
 


### PR DESCRIPTION
## Why
On 2026-06-26 the Cloudflare Worker `choiz-mcp-worker` came up with **no secrets** (deleted/recreated manually — no CI/git trace; the audit log shows no delete event). Every connector failed: first at registration (`X-Powered-By: Express` everywhere → Worker bypassed), then at Google sign-in (`client_id=undefined` → `invalid_client`). `monitor-tunnel` stayed green the whole time because it only probes the tunnel/gateway *behind* the Worker.

Restore was manual and artisanal. This PR makes it reproducible and monitored.

## What
- **`.github/workflows/bootstrap-worker-secrets.yml`** — `workflow_dispatch`: `wrangler deploy` then `wrangler secret put` ×4 from GitHub Actions Secrets (piped via stdin, masked in logs). One-click full restore. GitHub Secrets become the recoverable source of truth (Cloudflare + Vercel "Sensitive" vars can't be read back).
- **`.github/workflows/monitor-worker.yml`** — cron `*/15`: synthetic check of the Worker's OAuth surface the tunnel monitor can't see. Three checks mapping 1:1 to today's failures:
  - `/.well-known` served by Express → Worker not intercepting the route
  - `/authorize` redirects with `client_id=undefined` → `GOOGLE_CLIENT_ID` missing
  - `/api/warehouse/query` returns 503 → `DASHBOARD_API_KEY` missing
  Opens a deduped `[ops]` issue on failure.
- **`docs/NEXT_STEPS.md`** — notes the Cloudflare blast-radius hardening follow-up (the deploy token can delete the Worker).

## Before this helps
Add 4 repo secrets (Settings → Secrets and variables → Actions): `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `WORKER_SHARED_SECRET`, `DASHBOARD_API_KEY`. (`CLOUDFLARE_API_TOKEN` already exists.) Scheduled/dispatch workflows only run once on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)